### PR TITLE
Fix NODE_ENV and BABEL_ENV in test script

### DIFF
--- a/packages/libs/htz-react-base/scripts/test.js
+++ b/packages/libs/htz-react-base/scripts/test.js
@@ -2,6 +2,9 @@
 const path = require('path');
 const jest = require('jest');
 
+process.env.NODE_ENV = 'test';
+process.env.BABEL_ENV = 'commonjs';
+
 const packageInfo = require(path.join(process.cwd(), 'package.json'));
 
 const argv = process.argv.slice(2);


### PR DESCRIPTION
Since the Babel config now requires a `BABEL_ENV` to know what to do, and Jest runs the tests directly in Node (a CommonJS environment), we need to tell the test script to use `BABEL_ENV=commonjs`. 

Fixes #34.