### PR TITLE
fix(haaretz.co.il): Styleguide build with Yarn Workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "bootstrap": "yarn run clean && yarn run update",
+    "bootstrap": "yarn run clean && yarn run update && lerna exec --no-bail -- yarn run build",
     "clean": "lerna clean --yes && rimraf \"packages/*/*/{.jest,.next,dist}\"",
     "docs": "doctoc --title \"**Table of Contents**\" .",
     "format": "lerna exec --no-bail -- yarn run format",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "bootstrap": "yarn run clean && yarn run update && lerna exec --no-bail -- yarn run build",
+    "bootstrap": "yarn run clean && yarn run update && lerna run prepare",
     "clean": "lerna clean --yes && rimraf \"packages/*/*/{.jest,.next,dist}\"",
     "docs": "doctoc --title \"**Table of Contents**\" .",
     "format": "lerna exec --no-bail -- yarn run format",

--- a/packages/apps/haaretz.co.il/styleguide.config.js
+++ b/packages/apps/haaretz.co.il/styleguide.config.js
@@ -1,5 +1,5 @@
 const { configure, } = require('@haaretz/htz-react-base/styleguide');
-const htzComponentsPath = require('path').dirname(require.resolve('@haaretz/htz-components'));
+const htzComponentsPath = require('path').dirname(require.resolve('@haaretz/htz-components/package.json'));
 
 // When passed an object, `configure` will do a (shallow) extend of the default
 // config. If you need to extend a particular value (e.g. `styleguideComponents`),
@@ -17,7 +17,7 @@ module.exports = configure({
     {
       name: 'Shared Components',
       components:
-        `${htzComponentsPath}/../esnext/{,src}/**/[A-Z]*.{js,jsx}`,
+        `${htzComponentsPath}/src/**/[A-Z]*.{js,jsx}`,
     },
   ],
 });

--- a/packages/apps/haaretz.co.il/styleguide.config.js
+++ b/packages/apps/haaretz.co.il/styleguide.config.js
@@ -1,4 +1,5 @@
 const { configure, } = require('@haaretz/htz-react-base/styleguide');
+const htzComponentsPath = require('path').dirname(require.resolve('@haaretz/htz-components'));
 
 // When passed an object, `configure` will do a (shallow) extend of the default
 // config. If you need to extend a particular value (e.g. `styleguideComponents`),
@@ -16,7 +17,7 @@ module.exports = configure({
     {
       name: 'Shared Components',
       components:
-        'node_modules/@haaretz/htz-components/src/components/{,src}/**/[A-Z]*.{js,jsx}',
+        `${htzComponentsPath}/../esnext/{,src}/**/[A-Z]*.{js,jsx}`,
     },
   ],
 });


### PR DESCRIPTION
* Correctly resolve `@haaretz/htz-components` in the app styleguide 

closes #52
closes #53