### PR TITLE
docs(htz-css-tools): improve docs of "parseStyleProps" and "parseComponentProp"

### DIFF
--- a/docs/htz-css-tools/index.html
+++ b/docs/htz-css-tools/index.html
@@ -918,7 +918,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/color/createColorGetter.js#L60-L149'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/color/createColorGetter.js#L60-L149'>
       <span>packages/libs/htz-css-tools/src/color/createColorGetter.js</span>
       </a>
     
@@ -994,7 +994,7 @@ preconfigured theme.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/color/createColorGetter.js#L44-L48'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/color/createColorGetter.js#L44-L48'>
       <span>packages/libs/htz-css-tools/src/color/createColorGetter.js</span>
       </a>
     
@@ -1102,7 +1102,7 @@ styled differently from branded elements.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/color/createColorGetter.js#L28-L30'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/color/createColorGetter.js#L28-L30'>
       <span>packages/libs/htz-css-tools/src/color/createColorGetter.js</span>
       </a>
     
@@ -1203,7 +1203,7 @@ variant), or color-variant definitions.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L161-L211'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L161-L211'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1335,7 +1335,7 @@ on the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L117-L117'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L117-L117'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1520,7 +1520,7 @@ or a feature string, e.g.,
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L76-L81'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L76-L81'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1654,7 +1654,7 @@ string, e.g.,
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L37-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L37-L39'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1721,7 +1721,7 @@ as values.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L22-L24'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L22-L24'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1791,7 +1791,7 @@ May not contain a <code>default</code> property (it is used internally by the fr
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L52-L55'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L52-L55'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1899,15 +1899,33 @@ May not contain a <code>default</code> property (it is used internally by the fr
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L61-L96'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L113-L148'>
       <span>packages/libs/htz-css-tools/src/props/parseComponentProp.js</span>
       </a>
     
   </div>
   
 
-  <p>Parse the value of a React component's prop, and convert it to a
-CSS-in-JS object, responsive or otherwise.</p>
+  <p>Parse the value of React components' props that can take
+<a href="#componentpropresponsiveobject">responsive values</a>, and convert them
+to CSS-in-JS objects.</p>
+<p>Say we have a <MyComp /> component, that takes a <code>width</code> prop, which may have
+different values in different breakpoints. It may either be a number, or
+when the width of the component does not change, or an array of
+<code>ComponentPropResponsiveObject</code>s:</p>
+<pre class='hljs'>&lt;MyComp width={6} /&gt;</pre>
+<p>or</p>
+<pre class='hljs'>&lt;MyComp
+  width={[
+    { <span class="hljs-attr">until</span>: <span class="hljs-string">'s'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">6</span>, },
+    {<span class="hljs-attr">from</span>: <span class="hljs-string">'s'</span>, <span class="hljs-attr">until</span>: <span class="hljs-string">'l'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">8</span>, },
+    { <span class="hljs-attr">from</span>: <span class="hljs-string">'l'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">10</span>, },
+  ]}
+/&gt;</pre>
+<p>the <code>parseComponentProp</code> function can be used to create a <code>CSS-in-JS</code> object containing
+a media query for each of the conditions (or none at all, in the first, simple use-case),
+and pass the value of the <code>value</code> property of each of the objects to a
+<a href="#componentpropconverterfn">converter function</a>.</p>
 
 
   <div class='pre p1 fill-light mt0'>parseComponentProp(prop: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, values: <a href="#componentpropvalue">ComponentPropValue</a>, mq: <a href="#mqfunc">MqFunc</a>, converter: <a href="#componentpropconverterfn">ComponentPropConverterFn</a>?, converterArgs: ...any?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
@@ -1928,7 +1946,7 @@ CSS-in-JS object, responsive or otherwise.</p>
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>prop</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    The name of the React comoponent prop being parsed
+	    The name of the React component prop being parsed
 
           </div>
           
@@ -1958,20 +1976,26 @@ CSS-in-JS object, responsive or otherwise.</p>
 	    A callback used for converting 
 <code>values</code>
 
-(or each item in 
+(or the 
+<code>value</code>
+ prop in each item in 
 <code>values</code>
-, when it is an array) to a CSS-in-JS objcet. Passed the
-
+, when it is an array) to a CSS-in-JS object.
+Passed the 
 <code>prop</code>
  and 
 <code>values</code>
- as arguments, followd by those defined in 
+ as arguments, followed by those defined in 
 <code>converterArgs</code>
 .
 <br />
 
 In its absence, the returned object will simply be 
 <code>{ [prop]: values }</code>
+<p>  At its simplest, example of a converter function could be:</p>
+<pre class='hljs'><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">setWidth</span>(<span class="hljs-params">prop: string, value: number</span>): <span class="hljs-title">Object</span> </span>{
+  <span class="hljs-keyword">return</span> { <span class="hljs-attr">width</span>: <span class="hljs-string">`<span class="hljs-subst">${value * <span class="hljs-number">2</span>}</span>rem`</span>, };
+}</pre>
 
           </div>
           
@@ -2007,6 +2031,26 @@ after
   
 
   
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'>parseComponentProp(
+   <span class="hljs-comment">// prop:</span>
+  <span class="hljs-string">'width'</span>,
+  <span class="hljs-comment">// values:</span>
+  [
+    { <span class="hljs-attr">until</span>: <span class="hljs-string">'s'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">6</span>, },
+    {<span class="hljs-attr">from</span>: <span class="hljs-string">'s'</span>, <span class="hljs-attr">until</span>: <span class="hljs-string">'l'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">8</span>, },
+    { <span class="hljs-attr">from</span>: <span class="hljs-string">'l'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">10</span>, },
+  ],
+  <span class="hljs-comment">// media query function:</span>
+  theme.mq,
+  <span class="hljs-comment">// converter function:</span>
+  setWidth
+ <span class="hljs-comment">// adiditional args will be passed to the converter function //</span>
+);</pre>
+    
+  
 
   
 
@@ -2028,15 +2072,15 @@ after
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseStyleProps.js#L19-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseStyleProps.js#L39-L47'>
       <span>packages/libs/htz-css-tools/src/props/parseStyleProps.js</span>
       </a>
     
   </div>
   
 
-  <p>Parse an object of styleProps into an array of CSS-in-JS objects
-(Should always be spread inside and <code>extend</code> property)</p>
+  <p>Parse an object of miscellaneous styles into an array of CSS-in-JS
+objects (Should always be spread inside Fela's <code>extend</code> property).</p>
 
 
   <div class='pre p1 fill-light mt0'>parseStyleProps(styleProps: {}, mq: <a href="#mqfunc">MqFunc</a>, typesetter: <a href="#typesetter">Typesetter</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | void)></div>
@@ -2058,7 +2102,7 @@ after
           <div>
             <span class='code bold'>styleProps</span> <code class='quiet'>({})</code>
 	    An object of 
-<a href="https://haaretz.github.io/htz-frontend/htz-css-tools#styleprop"><code>StyleProp</code></a>
+<a href="#styleprop"><code>StyleProp</code></a>
 s to be parsed.
 
           </div>
@@ -2102,6 +2146,28 @@ s to be parsed.
   
 
   
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'>&lt;MyComponoent
+  miscStyles={{
+    <span class="hljs-attr">color</span>: <span class="hljs-string">'red'</span>,
+    <span class="hljs-attr">type</span>: <span class="hljs-number">2</span>,
+    <span class="hljs-attr">width</span>: [ {<span class="hljs-attr">from</span> : <span class="hljs-string">'s'</span>, <span class="hljs-attr">value</span>: <span class="hljs-string">'6rem'</span>}, ],
+  }}
+/&gt;
+
+<span class="hljs-keyword">const</span> MyComponoentStyles = <span class="hljs-function">(<span class="hljs-params">props</span>) =&gt;</span> ({
+  <span class="hljs-attr">extend</span>: [
+    ...(
+      props.miscStyles
+        ? parseStyleProps(props.miscStyles, props.theme.mq, props.theme.type)
+        : []
+    ),
+  ]
+});</pre>
+    
+  
 
   
 
@@ -2123,7 +2189,7 @@ s to be parsed.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L67-L165'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L67-L165'>
       <span>packages/libs/htz-css-tools/src/props/parseStyleProp.js</span>
       </a>
     
@@ -2300,7 +2366,7 @@ e.g., the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L14-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L14-L20'>
       <span>packages/libs/htz-css-tools/src/props/parseComponentProp.js</span>
       </a>
     
@@ -2426,7 +2492,7 @@ e.g., the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L25-L30'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L25-L30'>
       <span>packages/libs/htz-css-tools/src/props/parseComponentProp.js</span>
       </a>
     
@@ -2482,7 +2548,7 @@ e.g., the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L41-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L41-L45'>
       <span>packages/libs/htz-css-tools/src/props/parseComponentProp.js</span>
       </a>
     
@@ -2578,7 +2644,7 @@ e.g., the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L21-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L21-L28'>
       <span>packages/libs/htz-css-tools/src/props/parseStyleProp.js</span>
       </a>
     
@@ -2720,7 +2786,7 @@ e.g., the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L40-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L40-L43'>
       <span>packages/libs/htz-css-tools/src/props/parseStyleProp.js</span>
       </a>
     
@@ -2797,7 +2863,7 @@ May be one of:</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L105-L187'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L105-L187'>
       <span>packages/libs/htz-css-tools/src/typography/createTypesetter.js</span>
       </a>
     
@@ -2901,7 +2967,7 @@ based on the global typographic scale and vertical rhythm configuration.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/confTypes.js#L84-L87'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/confTypes.js#L84-L87'>
       <span>packages/libs/htz-css-tools/src/typography/confTypes.js</span>
       </a>
     
@@ -2998,7 +3064,7 @@ Larger breakpoints override smaller ones.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/confTypes.js#L45-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/confTypes.js#L45-L51'>
       <span>packages/libs/htz-css-tools/src/typography/confTypes.js</span>
       </a>
     
@@ -3163,7 +3229,7 @@ A
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L83-L86'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L83-L86'>
       <span>packages/libs/htz-css-tools/src/typography/createTypesetter.js</span>
       </a>
     
@@ -3333,7 +3399,7 @@ typesetter(<span class="hljs-number">1</span>, {<span class="hljs-attr">until</s
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L41-L46'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L41-L46'>
       <span>packages/libs/htz-css-tools/src/typography/createTypesetter.js</span>
       </a>
     
@@ -3467,7 +3533,7 @@ typesetter(<span class="hljs-number">1</span>, {<span class="hljs-attr">until</s
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L24-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L24-L27'>
       <span>packages/libs/htz-css-tools/src/typography/createTypesetter.js</span>
       </a>
     
@@ -3575,7 +3641,7 @@ global typographic scale configuration.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L81-L89'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L81-L89'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -3750,7 +3816,7 @@ border(<span class="hljs-string">'2px'</span>, <span class="hljs-number">0</span
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L140-L148'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L140-L148'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -3900,7 +3966,7 @@ borderTop(<span class="hljs-string">'2px'</span>, <span class="hljs-number">0</s
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L175-L182'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L175-L182'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4010,7 +4076,7 @@ borderEnd({ <span class="hljs-attr">width</span>: <span class="hljs-string">'2px
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L209-L216'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L209-L216'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4120,7 +4186,7 @@ borderRight({ <span class="hljs-attr">width</span>: <span class="hljs-string">'2
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L267-L275'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L267-L275'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4270,7 +4336,7 @@ borderBottom(<span class="hljs-string">'2px'</span>, <span class="hljs-number">0
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L302-L309'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L302-L309'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4380,7 +4446,7 @@ borderStart({ <span class="hljs-attr">width</span>: <span class="hljs-string">'2
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L336-L343'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L336-L343'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4490,7 +4556,7 @@ borderLeft({ <span class="hljs-attr">width</span>: <span class="hljs-string">'2p
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L373-L380'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L373-L380'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4603,7 +4669,7 @@ borderHorizontal({ <span class="hljs-attr">width</span>: <span class="hljs-strin
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L444-L452'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L444-L452'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4766,7 +4832,7 @@ border(<span class="hljs-string">'2px'</span>, <span class="hljs-number">0</span
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/types.js#L66-L71'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/types.js#L66-L71'>
       <span>packages/libs/htz-css-tools/src/border/types.js</span>
       </a>
     
@@ -4897,7 +4963,7 @@ relevant endge(s)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/types.js#L5-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/types.js#L5-L23'>
       <span>packages/libs/htz-css-tools/src/border/types.js</span>
       </a>
     
@@ -4953,7 +5019,7 @@ relevant endge(s)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/types.js#L74-L94'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/types.js#L74-L94'>
       <span>packages/libs/htz-css-tools/src/border/types.js</span>
       </a>
     
@@ -5104,7 +5170,7 @@ relevant endge(s)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/types.js#L26-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/types.js#L26-L37'>
       <span>packages/libs/htz-css-tools/src/border/types.js</span>
       </a>
     
@@ -5160,7 +5226,7 @@ relevant endge(s)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/types.js#L40-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/types.js#L40-L50'>
       <span>packages/libs/htz-css-tools/src/border/types.js</span>
       </a>
     
@@ -5231,7 +5297,7 @@ relevant endge(s)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mixins/visuallyHidden.js#L10-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mixins/visuallyHidden.js#L10-L40'>
       <span>packages/libs/htz-css-tools/src/mixins/visuallyHidden.js</span>
       </a>
     
@@ -5304,7 +5370,7 @@ via the keyboard
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mixins/autospace.js#L27-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mixins/autospace.js#L27-L33'>
       <span>packages/libs/htz-css-tools/src/mixins/autospace.js</span>
       </a>
     
@@ -5424,7 +5490,7 @@ The first
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/stripUnit.js#L14-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/stripUnit.js#L14-L20'>
       <span>packages/libs/htz-css-tools/src/units/stripUnit.js</span>
       </a>
     
@@ -5520,7 +5586,7 @@ The first
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/getUnit.js#L19-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/getUnit.js#L19-L22'>
       <span>packages/libs/htz-css-tools/src/units/getUnit.js</span>
       </a>
     
@@ -5608,7 +5674,7 @@ e.g.,
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/getLengthProps.js#L23-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/getLengthProps.js#L23-L29'>
       <span>packages/libs/htz-css-tools/src/units/getLengthProps.js</span>
       </a>
     
@@ -5698,7 +5764,7 @@ e.g.,
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/pxTo.js#L61-L80'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/pxTo.js#L61-L80'>
       <span>packages/libs/htz-css-tools/src/units/pxTo.js</span>
       </a>
     
@@ -5780,7 +5846,7 @@ e.g.,
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/pxTo.js#L124-L124'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/pxTo.js#L124-L124'>
       <span>packages/libs/htz-css-tools/src/units/pxTo.js</span>
       </a>
     
@@ -5889,7 +5955,7 @@ pxToEm([<span class="hljs-number">8</span>, <span class="hljs-number">24</span>]
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/createRemFunction.js#L50-L114'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/createRemFunction.js#L50-L114'>
       <span>packages/libs/htz-css-tools/src/units/createRemFunction.js</span>
       </a>
     
@@ -5995,7 +6061,7 @@ while accounting to changes in the vertical rhythm.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/createRemFunction.js#L25-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/createRemFunction.js#L25-L31'>
       <span>packages/libs/htz-css-tools/src/units/createRemFunction.js</span>
       </a>
     
@@ -6143,7 +6209,7 @@ while accounting to changes in vertical rhythm.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/getBorderOpts.js#L16-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/getBorderOpts.js#L16-L44'>
       <span>packages/libs/htz-css-tools/src/border/getBorderOpts.js</span>
       </a>
     
@@ -6242,7 +6308,7 @@ should occupy. Mandatory when not passing an object as the first argument
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/getBpsInRange.js#L18-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/getBpsInRange.js#L18-L47'>
       <span>packages/libs/htz-css-tools/src/helpers/getBpsInRange.js</span>
       </a>
     
@@ -6340,7 +6406,7 @@ getBpsInRange(bps, <span class="hljs-string">'m'</span>, <span class="hljs-strin
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/getClosestBp.js#L23-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/getClosestBp.js#L23-L38'>
       <span>packages/libs/htz-css-tools/src/helpers/getClosestBp.js</span>
       </a>
     
@@ -6458,7 +6524,7 @@ getClosestBp(<span class="hljs-string">'m'</span>, rhythmBps, allBps) <span clas
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getFontSize.js#L23-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getFontSize.js#L23-L31'>
       <span>packages/libs/htz-css-tools/src/typography/getFontSize.js</span>
       </a>
     
@@ -6571,7 +6637,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L235-L247'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L235-L247'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -6667,7 +6733,7 @@ and values representing lengths in pixels
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getLineHeight.js#L19-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getLineHeight.js#L19-L33'>
       <span>packages/libs/htz-css-tools/src/typography/getLineHeight.js</span>
       </a>
     
@@ -6778,7 +6844,7 @@ A
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getLinesWithPadding.js#L24-L36'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getLinesWithPadding.js#L24-L36'>
       <span>packages/libs/htz-css-tools/src/typography/getLinesWithPadding.js</span>
       </a>
     
@@ -6893,7 +6959,7 @@ should be given minimal vertical padding.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js#L43-L82'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js#L43-L82'>
       <span>packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js</span>
       </a>
     
@@ -7010,7 +7076,7 @@ getRhythmBpsData(bps, rhythmBps, <span class="hljs-string">'m'</span>)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L91-L114'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L91-L114'>
       <span>packages/libs/htz-css-tools/src/typography/getTypeProps.js</span>
       </a>
     
@@ -7184,7 +7250,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/isNamedBp.js#L21-L36'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/isNamedBp.js#L21-L36'>
       <span>packages/libs/htz-css-tools/src/helpers/isNamedBp.js</span>
       </a>
     
@@ -7291,7 +7357,7 @@ isNamedBp(<span class="hljs-string">'mobile'</span>, [<span class="hljs-string">
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/pxTo.js#L104-L104'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/pxTo.js#L104-L104'>
       <span>packages/libs/htz-css-tools/src/units/pxTo.js</span>
       </a>
     
@@ -7405,7 +7471,7 @@ pxToRem([<span class="hljs-number">12</span>, <span class="hljs-number">24</span
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/setBorder.js#L67-L126'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/setBorder.js#L67-L126'>
       <span>packages/libs/htz-css-tools/src/border/setBorder.js</span>
       </a>
     
@@ -7576,7 +7642,7 @@ setBorder(
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L37-L42'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L37-L42'>
       <span>packages/libs/htz-css-tools/src/helpers/styleFormatter.js</span>
       </a>
     
@@ -7662,7 +7728,7 @@ tagged template literals).</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js#L34-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js#L34-L41'>
       <span>packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js</span>
       </a>
     
@@ -7771,7 +7837,7 @@ to accommodate the various styles of different CSS-in-JS frameworks.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/consts/index.js#L7-L7'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/consts/index.js#L7-L7'>
       <span>packages/libs/htz-css-tools/src/consts/index.js</span>
       </a>
     
@@ -7842,7 +7908,7 @@ to accommodate the various styles of different CSS-in-JS frameworks.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L12-L12'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L12-L12'>
       <span>packages/libs/htz-css-tools/src/helpers/styleFormatter.js</span>
       </a>
     
@@ -7901,7 +7967,7 @@ for nesting.<br />
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js#L15-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js#L15-L15'>
       <span>packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js</span>
       </a>
     
@@ -7970,7 +8036,7 @@ previous items.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L49-L56'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L49-L56'>
       <span>packages/libs/htz-css-tools/src/typography/getTypeProps.js</span>
       </a>
     
@@ -8130,7 +8196,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/getLengthProps.js#L9-L9'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/getLengthProps.js#L9-L9'>
       <span>packages/libs/htz-css-tools/src/units/getLengthProps.js</span>
       </a>
     
@@ -8203,7 +8269,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/pxTo.js#L45-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/pxTo.js#L45-L45'>
       <span>packages/libs/htz-css-tools/src/units/pxTo.js</span>
       </a>
     
@@ -8302,7 +8368,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js#L14-L18'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js#L14-L18'>
       <span>packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js</span>
       </a>
     
@@ -8402,7 +8468,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L20-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L20-L20'>
       <span>packages/libs/htz-css-tools/src/helpers/styleFormatter.js</span>
       </a>
     
@@ -8460,7 +8526,7 @@ an array of style values, for generating fallback arguments.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/pxTo.js#L16-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/pxTo.js#L16-L26'>
       <span>packages/libs/htz-css-tools/src/units/pxTo.js</span>
       </a>
     
@@ -8516,7 +8582,7 @@ an array of style values, for generating fallback arguments.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L14-L19'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L14-L19'>
       <span>packages/libs/htz-css-tools/src/typography/getTypeProps.js</span>
       </a>
     
@@ -8648,7 +8714,7 @@ an array of style values, for generating fallback arguments.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L104-L114'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L156-L166'>
       <span>packages/libs/htz-css-tools/src/props/parseComponentProp.js</span>
       </a>
     

--- a/packages/libs/htz-css-tools/docs/index.html
+++ b/packages/libs/htz-css-tools/docs/index.html
@@ -918,7 +918,7 @@
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/color/createColorGetter.js#L60-L149'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/color/createColorGetter.js#L60-L149'>
       <span>packages/libs/htz-css-tools/src/color/createColorGetter.js</span>
       </a>
     
@@ -994,7 +994,7 @@ preconfigured theme.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/color/createColorGetter.js#L44-L48'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/color/createColorGetter.js#L44-L48'>
       <span>packages/libs/htz-css-tools/src/color/createColorGetter.js</span>
       </a>
     
@@ -1102,7 +1102,7 @@ styled differently from branded elements.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/color/createColorGetter.js#L28-L30'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/color/createColorGetter.js#L28-L30'>
       <span>packages/libs/htz-css-tools/src/color/createColorGetter.js</span>
       </a>
     
@@ -1203,7 +1203,7 @@ variant), or color-variant definitions.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L161-L211'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L161-L211'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1335,7 +1335,7 @@ on the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L117-L117'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L117-L117'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1520,7 +1520,7 @@ or a feature string, e.g.,
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L76-L81'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L76-L81'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1654,7 +1654,7 @@ string, e.g.,
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L37-L39'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L37-L39'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1721,7 +1721,7 @@ as values.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L22-L24'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L22-L24'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1791,7 +1791,7 @@ May not contain a <code>default</code> property (it is used internally by the fr
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L52-L55'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L52-L55'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -1899,15 +1899,33 @@ May not contain a <code>default</code> property (it is used internally by the fr
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L61-L96'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L113-L148'>
       <span>packages/libs/htz-css-tools/src/props/parseComponentProp.js</span>
       </a>
     
   </div>
   
 
-  <p>Parse the value of a React component's prop, and convert it to a
-CSS-in-JS object, responsive or otherwise.</p>
+  <p>Parse the value of React components' props that can take
+<a href="#componentpropresponsiveobject">responsive values</a>, and convert them
+to CSS-in-JS objects.</p>
+<p>Say we have a <MyComp /> component, that takes a <code>width</code> prop, which may have
+different values in different breakpoints. It may either be a number, or
+when the width of the component does not change, or an array of
+<code>ComponentPropResponsiveObject</code>s:</p>
+<pre class='hljs'>&lt;MyComp width={6} /&gt;</pre>
+<p>or</p>
+<pre class='hljs'>&lt;MyComp
+  width={[
+    { <span class="hljs-attr">until</span>: <span class="hljs-string">'s'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">6</span>, },
+    {<span class="hljs-attr">from</span>: <span class="hljs-string">'s'</span>, <span class="hljs-attr">until</span>: <span class="hljs-string">'l'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">8</span>, },
+    { <span class="hljs-attr">from</span>: <span class="hljs-string">'l'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">10</span>, },
+  ]}
+/&gt;</pre>
+<p>the <code>parseComponentProp</code> function can be used to create a <code>CSS-in-JS</code> object containing
+a media query for each of the conditions (or none at all, in the first, simple use-case),
+and pass the value of the <code>value</code> property of each of the objects to a
+<a href="#componentpropconverterfn">converter function</a>.</p>
 
 
   <div class='pre p1 fill-light mt0'>parseComponentProp(prop: <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>, values: <a href="#componentpropvalue">ComponentPropValue</a>, mq: <a href="#mqfunc">MqFunc</a>, converter: <a href="#componentpropconverterfn">ComponentPropConverterFn</a>?, converterArgs: ...any?): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a></div>
@@ -1928,7 +1946,7 @@ CSS-in-JS object, responsive or otherwise.</p>
         <div class='space-bottom0'>
           <div>
             <span class='code bold'>prop</span> <code class='quiet'>(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String">string</a>)</code>
-	    The name of the React comoponent prop being parsed
+	    The name of the React component prop being parsed
 
           </div>
           
@@ -1958,20 +1976,26 @@ CSS-in-JS object, responsive or otherwise.</p>
 	    A callback used for converting 
 <code>values</code>
 
-(or each item in 
+(or the 
+<code>value</code>
+ prop in each item in 
 <code>values</code>
-, when it is an array) to a CSS-in-JS objcet. Passed the
-
+, when it is an array) to a CSS-in-JS object.
+Passed the 
 <code>prop</code>
  and 
 <code>values</code>
- as arguments, followd by those defined in 
+ as arguments, followed by those defined in 
 <code>converterArgs</code>
 .
 <br />
 
 In its absence, the returned object will simply be 
 <code>{ [prop]: values }</code>
+<p>  At its simplest, example of a converter function could be:</p>
+<pre class='hljs'><span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-title">setWidth</span>(<span class="hljs-params">prop: string, value: number</span>): <span class="hljs-title">Object</span> </span>{
+  <span class="hljs-keyword">return</span> { <span class="hljs-attr">width</span>: <span class="hljs-string">`<span class="hljs-subst">${value * <span class="hljs-number">2</span>}</span>rem`</span>, };
+}</pre>
 
           </div>
           
@@ -2007,6 +2031,26 @@ after
   
 
   
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'>parseComponentProp(
+   <span class="hljs-comment">// prop:</span>
+  <span class="hljs-string">'width'</span>,
+  <span class="hljs-comment">// values:</span>
+  [
+    { <span class="hljs-attr">until</span>: <span class="hljs-string">'s'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">6</span>, },
+    {<span class="hljs-attr">from</span>: <span class="hljs-string">'s'</span>, <span class="hljs-attr">until</span>: <span class="hljs-string">'l'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">8</span>, },
+    { <span class="hljs-attr">from</span>: <span class="hljs-string">'l'</span>, <span class="hljs-attr">value</span>: <span class="hljs-number">10</span>, },
+  ],
+  <span class="hljs-comment">// media query function:</span>
+  theme.mq,
+  <span class="hljs-comment">// converter function:</span>
+  setWidth
+ <span class="hljs-comment">// adiditional args will be passed to the converter function //</span>
+);</pre>
+    
+  
 
   
 
@@ -2028,15 +2072,15 @@ after
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseStyleProps.js#L19-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseStyleProps.js#L39-L47'>
       <span>packages/libs/htz-css-tools/src/props/parseStyleProps.js</span>
       </a>
     
   </div>
   
 
-  <p>Parse an object of styleProps into an array of CSS-in-JS objects
-(Should always be spread inside and <code>extend</code> property)</p>
+  <p>Parse an object of miscellaneous styles into an array of CSS-in-JS
+objects (Should always be spread inside Fela's <code>extend</code> property).</p>
 
 
   <div class='pre p1 fill-light mt0'>parseStyleProps(styleProps: {}, mq: <a href="#mqfunc">MqFunc</a>, typesetter: <a href="#typesetter">Typesetter</a>): <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array">Array</a>&#x3C;(<a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object">Object</a> | void)></div>
@@ -2058,7 +2102,7 @@ after
           <div>
             <span class='code bold'>styleProps</span> <code class='quiet'>({})</code>
 	    An object of 
-<a href="https://haaretz.github.io/htz-frontend/htz-css-tools#styleprop"><code>StyleProp</code></a>
+<a href="#styleprop"><code>StyleProp</code></a>
 s to be parsed.
 
           </div>
@@ -2102,6 +2146,28 @@ s to be parsed.
   
 
   
+    <div class='py1 quiet mt1 prose-big'>Example</div>
+    
+      
+      <pre class='p1 overflow-auto round fill-light'>&lt;MyComponoent
+  miscStyles={{
+    <span class="hljs-attr">color</span>: <span class="hljs-string">'red'</span>,
+    <span class="hljs-attr">type</span>: <span class="hljs-number">2</span>,
+    <span class="hljs-attr">width</span>: [ {<span class="hljs-attr">from</span> : <span class="hljs-string">'s'</span>, <span class="hljs-attr">value</span>: <span class="hljs-string">'6rem'</span>}, ],
+  }}
+/&gt;
+
+<span class="hljs-keyword">const</span> MyComponoentStyles = <span class="hljs-function">(<span class="hljs-params">props</span>) =&gt;</span> ({
+  <span class="hljs-attr">extend</span>: [
+    ...(
+      props.miscStyles
+        ? parseStyleProps(props.miscStyles, props.theme.mq, props.theme.type)
+        : []
+    ),
+  ]
+});</pre>
+    
+  
 
   
 
@@ -2123,7 +2189,7 @@ s to be parsed.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L67-L165'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L67-L165'>
       <span>packages/libs/htz-css-tools/src/props/parseStyleProp.js</span>
       </a>
     
@@ -2300,7 +2366,7 @@ e.g., the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L14-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L14-L20'>
       <span>packages/libs/htz-css-tools/src/props/parseComponentProp.js</span>
       </a>
     
@@ -2426,7 +2492,7 @@ e.g., the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L25-L30'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L25-L30'>
       <span>packages/libs/htz-css-tools/src/props/parseComponentProp.js</span>
       </a>
     
@@ -2482,7 +2548,7 @@ e.g., the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L41-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L41-L45'>
       <span>packages/libs/htz-css-tools/src/props/parseComponentProp.js</span>
       </a>
     
@@ -2578,7 +2644,7 @@ e.g., the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L21-L28'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L21-L28'>
       <span>packages/libs/htz-css-tools/src/props/parseStyleProp.js</span>
       </a>
     
@@ -2720,7 +2786,7 @@ e.g., the
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L40-L43'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseStyleProp.js#L40-L43'>
       <span>packages/libs/htz-css-tools/src/props/parseStyleProp.js</span>
       </a>
     
@@ -2797,7 +2863,7 @@ May be one of:</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L105-L187'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L105-L187'>
       <span>packages/libs/htz-css-tools/src/typography/createTypesetter.js</span>
       </a>
     
@@ -2901,7 +2967,7 @@ based on the global typographic scale and vertical rhythm configuration.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/confTypes.js#L84-L87'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/confTypes.js#L84-L87'>
       <span>packages/libs/htz-css-tools/src/typography/confTypes.js</span>
       </a>
     
@@ -2998,7 +3064,7 @@ Larger breakpoints override smaller ones.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/confTypes.js#L45-L51'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/confTypes.js#L45-L51'>
       <span>packages/libs/htz-css-tools/src/typography/confTypes.js</span>
       </a>
     
@@ -3163,7 +3229,7 @@ A
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L83-L86'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L83-L86'>
       <span>packages/libs/htz-css-tools/src/typography/createTypesetter.js</span>
       </a>
     
@@ -3333,7 +3399,7 @@ typesetter(<span class="hljs-number">1</span>, {<span class="hljs-attr">until</s
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L41-L46'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L41-L46'>
       <span>packages/libs/htz-css-tools/src/typography/createTypesetter.js</span>
       </a>
     
@@ -3467,7 +3533,7 @@ typesetter(<span class="hljs-number">1</span>, {<span class="hljs-attr">until</s
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L24-L27'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/createTypesetter.js#L24-L27'>
       <span>packages/libs/htz-css-tools/src/typography/createTypesetter.js</span>
       </a>
     
@@ -3575,7 +3641,7 @@ global typographic scale configuration.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L81-L89'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L81-L89'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -3750,7 +3816,7 @@ border(<span class="hljs-string">'2px'</span>, <span class="hljs-number">0</span
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L140-L148'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L140-L148'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -3900,7 +3966,7 @@ borderTop(<span class="hljs-string">'2px'</span>, <span class="hljs-number">0</s
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L175-L182'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L175-L182'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4010,7 +4076,7 @@ borderEnd({ <span class="hljs-attr">width</span>: <span class="hljs-string">'2px
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L209-L216'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L209-L216'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4120,7 +4186,7 @@ borderRight({ <span class="hljs-attr">width</span>: <span class="hljs-string">'2
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L267-L275'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L267-L275'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4270,7 +4336,7 @@ borderBottom(<span class="hljs-string">'2px'</span>, <span class="hljs-number">0
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L302-L309'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L302-L309'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4380,7 +4446,7 @@ borderStart({ <span class="hljs-attr">width</span>: <span class="hljs-string">'2
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L336-L343'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L336-L343'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4490,7 +4556,7 @@ borderLeft({ <span class="hljs-attr">width</span>: <span class="hljs-string">'2p
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L373-L380'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L373-L380'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4603,7 +4669,7 @@ borderHorizontal({ <span class="hljs-attr">width</span>: <span class="hljs-strin
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/index.js#L444-L452'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/index.js#L444-L452'>
       <span>packages/libs/htz-css-tools/src/border/index.js</span>
       </a>
     
@@ -4766,7 +4832,7 @@ border(<span class="hljs-string">'2px'</span>, <span class="hljs-number">0</span
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/types.js#L66-L71'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/types.js#L66-L71'>
       <span>packages/libs/htz-css-tools/src/border/types.js</span>
       </a>
     
@@ -4897,7 +4963,7 @@ relevant endge(s)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/types.js#L5-L23'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/types.js#L5-L23'>
       <span>packages/libs/htz-css-tools/src/border/types.js</span>
       </a>
     
@@ -4953,7 +5019,7 @@ relevant endge(s)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/types.js#L74-L94'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/types.js#L74-L94'>
       <span>packages/libs/htz-css-tools/src/border/types.js</span>
       </a>
     
@@ -5104,7 +5170,7 @@ relevant endge(s)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/types.js#L26-L37'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/types.js#L26-L37'>
       <span>packages/libs/htz-css-tools/src/border/types.js</span>
       </a>
     
@@ -5160,7 +5226,7 @@ relevant endge(s)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/types.js#L40-L50'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/types.js#L40-L50'>
       <span>packages/libs/htz-css-tools/src/border/types.js</span>
       </a>
     
@@ -5231,7 +5297,7 @@ relevant endge(s)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mixins/visuallyHidden.js#L10-L40'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mixins/visuallyHidden.js#L10-L40'>
       <span>packages/libs/htz-css-tools/src/mixins/visuallyHidden.js</span>
       </a>
     
@@ -5304,7 +5370,7 @@ via the keyboard
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mixins/autospace.js#L27-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mixins/autospace.js#L27-L33'>
       <span>packages/libs/htz-css-tools/src/mixins/autospace.js</span>
       </a>
     
@@ -5424,7 +5490,7 @@ The first
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/stripUnit.js#L14-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/stripUnit.js#L14-L20'>
       <span>packages/libs/htz-css-tools/src/units/stripUnit.js</span>
       </a>
     
@@ -5520,7 +5586,7 @@ The first
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/getUnit.js#L19-L22'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/getUnit.js#L19-L22'>
       <span>packages/libs/htz-css-tools/src/units/getUnit.js</span>
       </a>
     
@@ -5608,7 +5674,7 @@ e.g.,
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/getLengthProps.js#L23-L29'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/getLengthProps.js#L23-L29'>
       <span>packages/libs/htz-css-tools/src/units/getLengthProps.js</span>
       </a>
     
@@ -5698,7 +5764,7 @@ e.g.,
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/pxTo.js#L61-L80'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/pxTo.js#L61-L80'>
       <span>packages/libs/htz-css-tools/src/units/pxTo.js</span>
       </a>
     
@@ -5780,7 +5846,7 @@ e.g.,
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/pxTo.js#L124-L124'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/pxTo.js#L124-L124'>
       <span>packages/libs/htz-css-tools/src/units/pxTo.js</span>
       </a>
     
@@ -5889,7 +5955,7 @@ pxToEm([<span class="hljs-number">8</span>, <span class="hljs-number">24</span>]
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/createRemFunction.js#L50-L114'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/createRemFunction.js#L50-L114'>
       <span>packages/libs/htz-css-tools/src/units/createRemFunction.js</span>
       </a>
     
@@ -5995,7 +6061,7 @@ while accounting to changes in the vertical rhythm.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/createRemFunction.js#L25-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/createRemFunction.js#L25-L31'>
       <span>packages/libs/htz-css-tools/src/units/createRemFunction.js</span>
       </a>
     
@@ -6143,7 +6209,7 @@ while accounting to changes in vertical rhythm.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/getBorderOpts.js#L16-L44'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/getBorderOpts.js#L16-L44'>
       <span>packages/libs/htz-css-tools/src/border/getBorderOpts.js</span>
       </a>
     
@@ -6242,7 +6308,7 @@ should occupy. Mandatory when not passing an object as the first argument
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/getBpsInRange.js#L18-L47'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/getBpsInRange.js#L18-L47'>
       <span>packages/libs/htz-css-tools/src/helpers/getBpsInRange.js</span>
       </a>
     
@@ -6340,7 +6406,7 @@ getBpsInRange(bps, <span class="hljs-string">'m'</span>, <span class="hljs-strin
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/getClosestBp.js#L23-L38'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/getClosestBp.js#L23-L38'>
       <span>packages/libs/htz-css-tools/src/helpers/getClosestBp.js</span>
       </a>
     
@@ -6458,7 +6524,7 @@ getClosestBp(<span class="hljs-string">'m'</span>, rhythmBps, allBps) <span clas
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getFontSize.js#L23-L31'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getFontSize.js#L23-L31'>
       <span>packages/libs/htz-css-tools/src/typography/getFontSize.js</span>
       </a>
     
@@ -6571,7 +6637,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/mq/mq.js#L235-L247'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/mq/mq.js#L235-L247'>
       <span>packages/libs/htz-css-tools/src/mq/mq.js</span>
       </a>
     
@@ -6667,7 +6733,7 @@ and values representing lengths in pixels
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getLineHeight.js#L19-L33'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getLineHeight.js#L19-L33'>
       <span>packages/libs/htz-css-tools/src/typography/getLineHeight.js</span>
       </a>
     
@@ -6778,7 +6844,7 @@ A
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getLinesWithPadding.js#L24-L36'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getLinesWithPadding.js#L24-L36'>
       <span>packages/libs/htz-css-tools/src/typography/getLinesWithPadding.js</span>
       </a>
     
@@ -6893,7 +6959,7 @@ should be given minimal vertical padding.
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js#L43-L82'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js#L43-L82'>
       <span>packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js</span>
       </a>
     
@@ -7010,7 +7076,7 @@ getRhythmBpsData(bps, rhythmBps, <span class="hljs-string">'m'</span>)
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L91-L114'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L91-L114'>
       <span>packages/libs/htz-css-tools/src/typography/getTypeProps.js</span>
       </a>
     
@@ -7184,7 +7250,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/isNamedBp.js#L21-L36'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/isNamedBp.js#L21-L36'>
       <span>packages/libs/htz-css-tools/src/helpers/isNamedBp.js</span>
       </a>
     
@@ -7291,7 +7357,7 @@ isNamedBp(<span class="hljs-string">'mobile'</span>, [<span class="hljs-string">
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/pxTo.js#L104-L104'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/pxTo.js#L104-L104'>
       <span>packages/libs/htz-css-tools/src/units/pxTo.js</span>
       </a>
     
@@ -7405,7 +7471,7 @@ pxToRem([<span class="hljs-number">12</span>, <span class="hljs-number">24</span
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/border/setBorder.js#L67-L126'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/border/setBorder.js#L67-L126'>
       <span>packages/libs/htz-css-tools/src/border/setBorder.js</span>
       </a>
     
@@ -7576,7 +7642,7 @@ setBorder(
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L37-L42'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L37-L42'>
       <span>packages/libs/htz-css-tools/src/helpers/styleFormatter.js</span>
       </a>
     
@@ -7662,7 +7728,7 @@ tagged template literals).</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js#L34-L41'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js#L34-L41'>
       <span>packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js</span>
       </a>
     
@@ -7771,7 +7837,7 @@ to accommodate the various styles of different CSS-in-JS frameworks.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/consts/index.js#L7-L7'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/consts/index.js#L7-L7'>
       <span>packages/libs/htz-css-tools/src/consts/index.js</span>
       </a>
     
@@ -7842,7 +7908,7 @@ to accommodate the various styles of different CSS-in-JS frameworks.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L12-L12'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L12-L12'>
       <span>packages/libs/htz-css-tools/src/helpers/styleFormatter.js</span>
       </a>
     
@@ -7901,7 +7967,7 @@ for nesting.<br />
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js#L15-L15'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js#L15-L15'>
       <span>packages/libs/htz-css-tools/src/helpers/fallbackFormatter.js</span>
       </a>
     
@@ -7970,7 +8036,7 @@ previous items.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L49-L56'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L49-L56'>
       <span>packages/libs/htz-css-tools/src/typography/getTypeProps.js</span>
       </a>
     
@@ -8130,7 +8196,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/getLengthProps.js#L9-L9'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/getLengthProps.js#L9-L9'>
       <span>packages/libs/htz-css-tools/src/units/getLengthProps.js</span>
       </a>
     
@@ -8203,7 +8269,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/pxTo.js#L45-L45'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/pxTo.js#L45-L45'>
       <span>packages/libs/htz-css-tools/src/units/pxTo.js</span>
       </a>
     
@@ -8302,7 +8368,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js#L14-L18'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js#L14-L18'>
       <span>packages/libs/htz-css-tools/src/helpers/getRhythmBpsData.js</span>
       </a>
     
@@ -8402,7 +8468,7 @@ the specified number of steps.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L20-L20'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/helpers/styleFormatter.js#L20-L20'>
       <span>packages/libs/htz-css-tools/src/helpers/styleFormatter.js</span>
       </a>
     
@@ -8460,7 +8526,7 @@ an array of style values, for generating fallback arguments.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/units/pxTo.js#L16-L26'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/units/pxTo.js#L16-L26'>
       <span>packages/libs/htz-css-tools/src/units/pxTo.js</span>
       </a>
     
@@ -8516,7 +8582,7 @@ an array of style values, for generating fallback arguments.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L14-L19'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/typography/getTypeProps.js#L14-L19'>
       <span>packages/libs/htz-css-tools/src/typography/getTypeProps.js</span>
       </a>
     
@@ -8648,7 +8714,7 @@ an array of style values, for generating fallback arguments.</p>
     </h3>
     
     
-      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/5b921fe3a4df4c9500958aaa524a4a684bd50ce5/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L104-L114'>
+      <a class='fr fill-darken0 round round pad1x quiet h5' href='https://github.com/Haaretz/htz-frontend/blob/1d9554049ab9d299c57e5188989b2b4ce9eb9603/packages/libs/htz-css-tools/src/props/parseComponentProp.js#L156-L166'>
       <span>packages/libs/htz-css-tools/src/props/parseComponentProp.js</span>
       </a>
     

--- a/packages/libs/htz-css-tools/src/props/parseComponentProp.js
+++ b/packages/libs/htz-css-tools/src/props/parseComponentProp.js
@@ -45,18 +45,70 @@ export type ComponentPropConverterFn = (
 ) => Object;
 
 /**
- * Parse the value of a React component's prop, and convert it to a
- * CSS-in-JS object, responsive or otherwise.
+ * Parse the value of React components' props that can take
+ * [responsive values](#componentpropresponsiveobject), and convert them
+ * to CSS-in-JS objects.
  *
- * @param {string} prop - The name of the React comoponent prop being parsed
+ * Say we have a <MyComp /> component, that takes a `width` prop, which may have
+ * different values in different breakpoints. It may either be a number, or
+ * when the width of the component does not change, or an array of
+ * `ComponentPropResponsiveObject`s:
+ *
+ * ```jsx
+ * <MyComp width={6} />
+ * ```
+ *
+ * or
+ *
+ * ```jsx
+ * <MyComp
+ *   width={[
+ *     { until: 's', value: 6, },
+ *     {from: 's', until: 'l', value: 8, },
+ *     { from: 'l', value: 10, },
+ *   ]}
+ * />
+ * ```
+ *
+ * the `parseComponentProp` function can be used to create a `CSS-in-JS` object containing
+ * a media query for each of the conditions (or none at all, in the first, simple use-case),
+ * and pass the value of the `value` property of each of the objects to a
+ * [converter function](#componentpropconverterfn).
+ *
+ * @param {string} prop - The name of the React component prop being parsed
  * @param {ComponentPropValue} values - The prop's value.
  * @param {MqFunc} mq - A media query function.
  * @param {ComponentPropConverterFn} [converter] - A callback used for converting `values`
- *   (or each item in `values`, when it is an array) to a CSS-in-JS objcet. Passed the
- *   `prop` and `values` as arguments, followd by those defined in `converterArgs`.<br />
+ *   (or the `value` prop in each item in `values`, when it is an array) to a CSS-in-JS object.
+ *   Passed the `prop` and `values` as arguments, followed by those defined in `converterArgs`.<br />
  *   In its absence, the returned object will simply be `{ [prop]: values }`
+ *
+ *   At its simplest, example of a converter function could be:
+ *
+ *   ```js
+ *   function setWidth(prop: string, value: number): Object {
+ *     return { width: `${value * 2}rem`, };
+ *   }
+ *   ```
  * @param {...*} [converterArgs] - Arguments to be passed to the `converter` function
  *   after `prop` and `value`
+ *
+ * @example
+ * parseComponentProp(
+ *    // prop:
+ *   'width',
+ *   // values:
+ *   [
+ *     { until: 's', value: 6, },
+ *     {from: 's', until: 'l', value: 8, },
+ *     { from: 'l', value: 10, },
+ *   ],
+ *   // media query function:
+ *   theme.mq,
+ *   // converter function:
+ *   setWidth
+ *  // adiditional args will be passed to the converter function //
+ * );
  */
 export default function parseComponentProp(
   prop: string,

--- a/packages/libs/htz-css-tools/src/props/parseStyleProps.js
+++ b/packages/libs/htz-css-tools/src/props/parseStyleProps.js
@@ -7,14 +7,34 @@ import type { Typesetter, } from '../typography/createTypesetter';
 import type { StyleProp, } from './parseStyleProp';
 
 /**
- * Parse an object of styleProps into an array of CSS-in-JS objects
- * (Should always be spread inside and `extend` property)
+ * Parse an object of miscellaneous styles into an array of CSS-in-JS
+ * objects (Should always be spread inside Fela's `extend` property).
  *
- * @param styleProps - An object of [`StyleProp`](https://haaretz.github.io/htz-frontend/htz-css-tools#styleprop)s to be parsed.
+ * @param styleProps - An object of [`StyleProp`](#styleprop)s to be parsed.
  * @param mq - a media-query function
  * @param typesetter - a typesetter function
  *
  * @return - an array of CSS-in-JS objects parsed from `styleProps`
+ *
+ * @example
+ * <MyComponoent
+ *   miscStyles={{
+ *     color: 'red',
+ *     type: 2,
+ *     width: [ {from : 's', value: '6rem'}, ],
+ *   }}
+ * />
+ *
+ * const MyComponoentStyles = (props) => ({
+ *   extend: [
+ *     ...(
+ *       props.miscStyles
+ *         ? parseStyleProps(props.miscStyles, props.theme.mq, props.theme.type)
+ *         : []
+ *     ),
+ *   ]
+ * });
+ *
  */
 export default function parseStyleProps(
   styleProps: { [key: string]: StyleProp },


### PR DESCRIPTION
affects: @haaretz/htz-css-tools

## Description
This pull request is aimed at improving the documentation of the `parseStyleProps` and `parseComponentProp`, by changing confusing language, expanding explanations and
providing usage examples.