### PR TITLE
fix(components): fix breaking-news component empty items

### DIFF
--- a/packages/components/htz-components/src/components/BreakingNewsBox/BreakingNewsBox.js
+++ b/packages/components/htz-components/src/components/BreakingNewsBox/BreakingNewsBox.js
@@ -59,7 +59,7 @@ export default class BreakingNewsBox extends React.Component<Props, State> {
         variables={{ cid: 'Haaretz.Element.BreakingNewsBoxElement', }}
       >
         {({ data, loading, error, }) => {
-          if (loading || error || !(data && data.breakingNewsBox)) {
+          if (loading || error || !(data && data.breakingNewsBox && data.breakingNewsBox.items)) {
             return null;
           }
 


### PR DESCRIPTION
affects: @haaretz/htz-components

<!-- START doctoc generated TOC please keep comment here to allow auto update -->
<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
**Table of Contents**

- [Description](#description)
- [Checklist](#checklist)

<!-- END doctoc generated TOC please keep comment here to allow auto update -->

**Related issue(s):** #0

## Description
<!-- Technical description of the task -->


<!-- Delete if none -->
**Notes:**
<!-- Extra notes on implementation, concerns, things to notice in review -->


## Checklist

Design:
  * [ ] Approved by designer

Usability:
  * [ ] Developer
  * [ ] Project manager

Tests
  <!-- remove irrelevant (but not incompolete) entries -->
  * [ ] UI snapshot testing 
  * [ ] Unit testing
  * [ ] Integration testing
  * [ ] E2E testing
