### PR TITLE
fix(standard article query): change path variable in query

### DIFF
--- a/packages/apps/haaretz.co.il/layouts/ArticleLayout.js
+++ b/packages/apps/haaretz.co.il/layouts/ArticleLayout.js
@@ -41,7 +41,7 @@ class ArticleLayout extends React.Component {
   static propTypes = {
     /**
      * The render function of the Layout, should return react elements,
-     * The render prop function is passed a Object with articleId and slots properties
+     * The render prop function is passed a Object with articleId, slots and path properties
      */
     render: PropTypes.func.isRequired,
     /**
@@ -176,7 +176,12 @@ class ArticleLayout extends React.Component {
                         minHeight: '100vh',
                       }}
                     >
-                      {render({ articleId: this.props.url.query.path, slots, pageType, })}
+                      {render({
+                        articleId: this.props.url.query.path,
+                        slots,
+                        pageType,
+                        path: lineage[0].url || this.props.url.query.path,
+                      })}
                     </FelaComponent>
                     <WelcomePage />
                   </Fragment>

--- a/packages/apps/haaretz.co.il/pages/magazineArticle.js
+++ b/packages/apps/haaretz.co.il/pages/magazineArticle.js
@@ -20,7 +20,7 @@ function MagArticlePage({ url, }) {
   return (
     <ArticleLayout
       url={url}
-      render={({ articleId, slots, }) => <MagazineArticle articleId={articleId} slots={slots} />}
+      render={({ articleId, slots, path, }) => <MagazineArticle articleId={articleId} slots={slots} path={path} />}
     />
   );
 }

--- a/packages/apps/haaretz.co.il/pages/recipeArticle.js
+++ b/packages/apps/haaretz.co.il/pages/recipeArticle.js
@@ -20,7 +20,7 @@ function RecipeArticlePage({ url, }) {
   return (
     <ArticleLayout
       url={url}
-      render={({ articleId, slots, }) => <RecipeArticle articleId={articleId} slots={slots} />}
+      render={({ articleId, slots, path, }) => <RecipeArticle articleId={articleId} slots={slots} path={path} />}
     />
   );
 }

--- a/packages/apps/haaretz.co.il/pages/reviewArticle.js
+++ b/packages/apps/haaretz.co.il/pages/reviewArticle.js
@@ -20,7 +20,7 @@ function ReviewArticlePage({ url, }) {
   return (
     <ArticleLayout
       url={url}
-      render={({ articleId, slots, }) => <ReviewArticle articleId={articleId} slots={slots} />}
+      render={({ articleId, slots, path, }) => <ReviewArticle articleId={articleId} slots={slots} path={path} />}
     />
   );
 }

--- a/packages/apps/haaretz.co.il/pages/standardArticle.js
+++ b/packages/apps/haaretz.co.il/pages/standardArticle.js
@@ -21,10 +21,10 @@ function StandardArticlePage({ url, }) {
   return (
     <ArticleLayout
       url={url}
-      render={({ articleId, slots, pageType, }) => (pageType !== 'regularArticle' ? (
+      render={({ articleId, slots, pageType, path, }) => (pageType !== 'regularArticle' ? (
         <LegacyPrefixRedirect pageType={pageType} />
       ) : (
-        <StandardArticle articleId={articleId} slots={slots} />
+        <StandardArticle articleId={articleId} slots={slots} path={path} />
       ))
       }
     />

--- a/packages/components/htz-components/src/components/ArticleGallery/ArticleGallery.js
+++ b/packages/components/htz-components/src/components/ArticleGallery/ArticleGallery.js
@@ -40,7 +40,7 @@ const ArticleGalleryQuery: DocumentNode = gql`
 `;
 
 type Props = {
-  articleId: string,
+  path: string,
 };
 
 const filterData: Array<any> => Array<ImageDataType> = article => (
@@ -74,11 +74,11 @@ const closeGallery: Object => void = client => {
 const getImageIndex: (Array<ImageDataType>, string) => number =
   (images, contentId) => images.findIndex(imageObj => imageObj.contentId === contentId);
 
-function ArticleGallery({ articleId, }: Props): Node {
+function ArticleGallery({ path, }: Props): Node {
   return (
     <Query
       query={ArticleGalleryQuery}
-      variables={{ path: articleId, }}
+      variables={{ path, }}
     >
       {({ loading, error, data, client, }) => {
         if (loading) return null;

--- a/packages/components/htz-components/src/components/ArticleTypes/LiveBlogArticle/LiveBlogArticle.js
+++ b/packages/components/htz-components/src/components/ArticleTypes/LiveBlogArticle/LiveBlogArticle.js
@@ -33,10 +33,10 @@ const IS_OSAKA_DISPLAYED = gql`
   }
 `;
 
-function LiveBlog({ articleId, slots, }) {
+function LiveBlog({ articleId, slots, path, }) {
   return (
     <ArticleLayout articleId={articleId} slots={slots}>
-      <Query query={LiveBlogQuery} partialRefetch variables={{ path: articleId, }}>
+      <Query query={LiveBlogQuery} partialRefetch variables={{ path, }}>
         {({ loading, error, data, }) => {
           if (loading) return null;
           if (error) return null;
@@ -380,7 +380,7 @@ function LiveBlog({ articleId, slots, }) {
                       </aside>
                     )}
                   />
-                  <ArticleGallery articleId={articleId} />
+                  <ArticleGallery path={path} />
                 </LayoutContainer>
               )}
             />
@@ -398,6 +398,7 @@ LiveBlog.propTypes = {
   articleId: PropTypes.string.isRequired,
 
   slots: PropTypes.shape({}).isRequired,
+  path: PropTypes.string.isRequired,
 };
 
 export default LiveBlog;

--- a/packages/components/htz-components/src/components/ArticleTypes/MagazineArticle/MagazineArticle.js
+++ b/packages/components/htz-components/src/components/ArticleTypes/MagazineArticle/MagazineArticle.js
@@ -47,7 +47,7 @@ const magazineLayout = {
   },
 };
 
-function MagazineArticle({ articleId, slots, }) {
+function MagazineArticle({ articleId, slots, path }) {
   return (
     <ArticleLayout
       articleId={articleId}
@@ -56,7 +56,7 @@ function MagazineArticle({ articleId, slots, }) {
       mastheadFullWidthBorder
       renderPostHeader={false}
     >
-      <Query query={MAGAZINE_ARTICLE_QUERY} partialRefetch variables={{ path: articleId, }}>
+      <Query query={MAGAZINE_ARTICLE_QUERY} partialRefetch variables={{ path, }}>
         {({ loading, error, data, }) => {
           if (loading) return null;
           if (error) return null;
@@ -270,7 +270,7 @@ function MagazineArticle({ articleId, slots, }) {
                             {...properties}
                           />
                         </ArticleLayoutRow>
-                        <ArticleGallery articleId={articleId} />
+                        <ArticleGallery path={path} />
                       </LayoutContainer>
                     );
                   })}
@@ -291,5 +291,6 @@ MagazineArticle.propTypes = {
   articleId: PropTypes.string.isRequired,
 
   slots: PropTypes.shape({}).isRequired,
+  path: PropTypes.string.isRequired,
 };
 export default MagazineArticle;

--- a/packages/components/htz-components/src/components/ArticleTypes/RecipeArticle/RecipeArticle.js
+++ b/packages/components/htz-components/src/components/ArticleTypes/RecipeArticle/RecipeArticle.js
@@ -22,10 +22,10 @@ import { buildUrl, } from '../../../utils/buildImgURLs';
 import RecipeArticleQuery from './queries/recipe_article';
 import ArticleGallery from '../../ArticleGallery/ArticleGallery';
 
-function RecipeArticle({ articleId, slots, }) {
+function RecipeArticle({ articleId, slots, path, }) {
   return (
     <ArticleLayout articleId={articleId} slots={slots}>
-      <Query query={RecipeArticleQuery} partialRefetch variables={{ path: articleId, }}>
+      <Query query={RecipeArticleQuery} partialRefetch variables={{ path, }}>
         {({ loading, error, data, }) => {
           if (loading) return null;
           if (error) return null;
@@ -264,7 +264,7 @@ function RecipeArticle({ articleId, slots, }) {
                       )}
                     />
                   </FelaComponent>
-                  <ArticleGallery articleId={articleId} />
+                  <ArticleGallery path={path} />
                 </LayoutContainer>
               )}
             />
@@ -282,6 +282,7 @@ RecipeArticle.propTypes = {
   articleId: PropTypes.string.isRequired,
 
   slots: PropTypes.shape({}).isRequired,
+  path: PropTypes.string.isRequired,
 };
 
 export default RecipeArticle;

--- a/packages/components/htz-components/src/components/ArticleTypes/ReviewArticle/ReviewArticle.js
+++ b/packages/components/htz-components/src/components/ArticleTypes/ReviewArticle/ReviewArticle.js
@@ -21,10 +21,10 @@ import { buildUrl, } from '../../../utils/buildImgURLs';
 import ReviewArticleQuery from './queries/review_article';
 import ArticleGallery from '../../ArticleGallery/ArticleGallery';
 
-function ReviewArticle({ articleId, slots, }) {
+function ReviewArticle({ articleId, slots, path, }) {
   return (
     <ArticleLayout articleId={articleId} slots={slots}>
-      <Query query={ReviewArticleQuery} partialRefetch variables={{ path: articleId, }}>
+      <Query query={ReviewArticleQuery} partialRefetch variables={{ path, }}>
         {({ loading, error, data, }) => {
           if (loading) return null;
           if (error) return null;
@@ -260,7 +260,7 @@ function ReviewArticle({ articleId, slots, }) {
                       )}
                     />
                   </FelaComponent>
-                  <ArticleGallery articleId={articleId} />
+                  <ArticleGallery path={path} />
                 </LayoutContainer>
               )}
             />
@@ -278,6 +278,7 @@ ReviewArticle.propTypes = {
   articleId: PropTypes.string.isRequired,
 
   slots: PropTypes.shape({}).isRequired,
+  path: PropTypes.string.isRequired,
 };
 
 export default ReviewArticle;

--- a/packages/components/htz-components/src/components/ArticleTypes/StandardArticle/StandardArticle.js
+++ b/packages/components/htz-components/src/components/ArticleTypes/StandardArticle/StandardArticle.js
@@ -21,10 +21,10 @@ import BloggerInfo from '../../BloggerInfo/BloggerInfo';
 import StandardArticleQuery from './queries/standard_article';
 import ArticleGallery from '../../ArticleGallery/ArticleGallery';
 
-function StandardArticle({ articleId, slots, }) {
+function StandardArticle({ articleId, slots, path, }) {
   return (
     <ArticleLayout articleId={articleId} slots={slots}>
-      <Query query={StandardArticleQuery} partialRefetch variables={{ path: articleId, }}>
+      <Query query={StandardArticleQuery} partialRefetch variables={{ path, }}>
         {({ loading, error, data, }) => {
           if (loading) return null;
           if (error) return null;
@@ -287,7 +287,7 @@ function StandardArticle({ articleId, slots, }) {
                       </aside>
                     )}
                   />
-                  <ArticleGallery articleId={articleId} />
+                  <ArticleGallery path={path} />
                 </LayoutContainer>
               )}
             />
@@ -305,6 +305,8 @@ StandardArticle.propTypes = {
   articleId: PropTypes.string.isRequired,
 
   slots: PropTypes.shape({}).isRequired,
+
+  path: PropTypes.string.isRequired,
 };
 
 export default StandardArticle;


### PR DESCRIPTION
affects: @haaretz/haaretz.co.il, @haaretz/htz-components

Newsletter registration component should now render the correct text, which may be specific to the article related section

**!!! This commit affects the content query for each article type, and thus has the potential for unforeseen side effects**

**Related issue(s):** #0

## Description
<!-- Technical description of the task -->

lineage[0].url is handed down as 'path' to the _render_ function inside __ArticleLayout__,
and is then used as the path variable inside __StandardArticle__ query.

This means that the full path will be used in the query and not just the article ID,
e.g. 'food/purim-recipes/1.3904083' and not '1.3904083',
which should yield more specific data. 


<!-- Delete if none -->
**Notes:**
<!-- Extra notes on implementation, concerns, things to notice in review -->
Amended: ArticleGallery queries the client, and so requires the same path variable used in the main article query. Since ArticleGallery is used in all article types, all were amended to use the full article path  as the path variable in their main query and all now pass that path variable to the ArticleGallery.

## Checklist

  * [ ] Approved by designer

Usability:
  * [ ] Developer
  * [ ] Project manager

Tests
  <!-- remove irrelevant (but not incomplete) entries -->
  * [ ] UI snapshot testing 
  * [ ] Unit testing
  * [ ] Integration testing
  * [ ] E2E testing
