### PR TITLE
fix(a11y related modifications): make changes in styling and a11y

### DIFF
--- a/packages/apps/purchase-page/components/OfferPage/Stages/ChooseProductStage.js
+++ b/packages/apps/purchase-page/components/OfferPage/Stages/ChooseProductStage.js
@@ -11,6 +11,7 @@ import {
   ApolloConsumer,
 } from '@haaretz/htz-components';
 import gql from 'graphql-tag';
+import { visuallyHidden, } from '@haaretz/htz-css-tools';
 import OfferList from './ChooseProductStageElements/OfferList';
 import Modal from './ChooseProductStageElements/Modal';
 import UserMessage from './Elements/UserMessage';
@@ -65,6 +66,27 @@ const couponButtonsMiscStyles = {
   marginInlineStart: '0.5rem',
   // width: '11rem',
 };
+
+const AriaHidden = ({ children, }) => (
+  <FelaComponent
+    style={visuallyHidden()}
+    render={({ className, }) => (
+      <span className={className}>{children}</span>
+    )}
+  />
+);
+AriaHidden.propTypes = { children: PropTypes.node.isRequired, };
+
+const AltPricingOption = ({ productTitle, }) => {
+  const specialOffer = productTitle.indexOf('מיוחד') !== -1;
+  return (
+    <Fragment>
+      {specialOffer && <AriaHidden>החלף ל</AriaHidden>}
+      {specialOffer ? productTitle : 'חזרה למחיר הרגיל'}
+    </Fragment>
+  );
+};
+AltPricingOption.propTypes = { productTitle: PropTypes.string.isRequired, };
 
 class ChooseProductStage extends Component {
   static propTypes = {
@@ -255,7 +277,7 @@ class ChooseProductStage extends Component {
                                   });
                                 }}
                               >
-                                {product.productTitle}
+                                <AltPricingOption productTitle={product.productTitle} />
                               </Button>
                             </Fragment>
                           ) : null)

--- a/packages/apps/purchase-page/components/OfferPage/Stages/ChooseProductStage.js
+++ b/packages/apps/purchase-page/components/OfferPage/Stages/ChooseProductStage.js
@@ -15,6 +15,7 @@ import { visuallyHidden, } from '@haaretz/htz-css-tools';
 import OfferList from './ChooseProductStageElements/OfferList';
 import Modal from './ChooseProductStageElements/Modal';
 import UserMessage from './Elements/UserMessage';
+import FelaTheme from 'react-fela/lib/FelaTheme';
 
 const gaMapper = {
   productId: {
@@ -67,7 +68,7 @@ const couponButtonsMiscStyles = {
   // width: '11rem',
 };
 
-const AriaHidden = ({ children, }) => (
+const A11yText = ({ children, }) => (
   <FelaComponent
     style={visuallyHidden()}
     render={({ className, }) => (
@@ -75,18 +76,23 @@ const AriaHidden = ({ children, }) => (
     )}
   />
 );
-AriaHidden.propTypes = { children: PropTypes.node.isRequired, };
+A11yText.propTypes = { children: PropTypes.node.isRequired, };
 
-const AltPricingOption = ({ productTitle, }) => {
-  const specialOffer = productTitle.indexOf('מיוחד') !== -1;
+const regularProductsContentIds = { 7.7504259: 1, 7.7602297: 1, };
+const AltPricingOption = ({ productContentId, productTitle, optionButtons, }) => {
+  const specialOffer = !(productContentId in regularProductsContentIds);
   return (
     <Fragment>
-      {specialOffer && <AriaHidden>החלף ל</AriaHidden>}
-      {specialOffer ? productTitle : 'חזרה למחיר הרגיל'}
+      {specialOffer && <A11yText>{optionButtons.a11yTexts.prefix}</A11yText>}
+      {specialOffer ? productTitle : optionButtons.regular}
     </Fragment>
   );
 };
-AltPricingOption.propTypes = { productTitle: PropTypes.string.isRequired, };
+AltPricingOption.propTypes = {
+  productContentId: PropTypes.string.isRequired,
+  productTitle: PropTypes.string.isRequired,
+  optionButtons: PropTypes.shape(PropTypes.object).isRequired,
+};
 
 class ChooseProductStage extends Component {
   static propTypes = {
@@ -203,7 +209,7 @@ class ChooseProductStage extends Component {
           theme: {
             stage2: {
               offerList: { termsButtonText, },
-              optionButtons: { coupon, },
+              optionButtons,
               form: {
                 couponError,
                 validation,
@@ -277,7 +283,11 @@ class ChooseProductStage extends Component {
                                   });
                                 }}
                               >
-                                <AltPricingOption productTitle={product.productTitle} />
+                                <AltPricingOption
+                                  productContentId={product.contentId}
+                                  productTitle={product.productTitle}
+                                  optionButtons={optionButtons}
+                                />
                               </Button>
                             </Fragment>
                           ) : null)
@@ -415,7 +425,7 @@ class ChooseProductStage extends Component {
                                 });
                               }}
                             >
-                              {coupon}
+                              {optionButtons.coupon}
                             </Button>
                           ))}
                         <FelaComponent

--- a/packages/apps/purchase-page/components/OfferPage/Stages/ChooseProductStage.js
+++ b/packages/apps/purchase-page/components/OfferPage/Stages/ChooseProductStage.js
@@ -15,7 +15,6 @@ import { visuallyHidden, } from '@haaretz/htz-css-tools';
 import OfferList from './ChooseProductStageElements/OfferList';
 import Modal from './ChooseProductStageElements/Modal';
 import UserMessage from './Elements/UserMessage';
-import FelaTheme from 'react-fela/lib/FelaTheme';
 
 const gaMapper = {
   productId: {

--- a/packages/apps/purchase-page/components/OfferPage/Stages/ChooseSlotsStageElements/DesktopView.js
+++ b/packages/apps/purchase-page/components/OfferPage/Stages/ChooseSlotsStageElements/DesktopView.js
@@ -142,7 +142,7 @@ const tdFootInnerContStyle = ({
   isHighlighted = false,
   theme,
 }) => ({
-  color: theme.color('offerPage', 'tableFooterText'),
+  color: theme.color('offerPage', isHighlighted ? 'tableFooterTextHighlighted' : 'tableFooterText'),
   cursor: 'pointer',
   fontWeight: 'bold',
   paddingTop: '4rem',
@@ -233,8 +233,8 @@ const tdInnerContStyle = ({
 });
 const StyledTdInnerCont = createComponent(tdInnerContStyle, 'div', [ 'onClick', ]);
 
-const pricingHeadStyle = theme => ({
-  color: theme.color('offerPage', 'pricingHeadText'),
+const pricingHeadStyle = (isHighlighted = false) => theme => ({
+  color: theme.color('offerPage', isHighlighted ? 'pricingHeadTextHighlighted' : 'pricingHeadText'),
   marginTop: '1rem',
   extend: [ theme.type(-1), ],
 });
@@ -383,7 +383,7 @@ function DesktopView({
                           />
                           <StyledColHead>{item.heading}</StyledColHead>
 
-                          <FelaComponent style={pricingHeadStyle} render="p">
+                          <FelaComponent style={pricingHeadStyle(idx === highlightedIndex)} render="p">
                             {item.pricingHead}
                           </FelaComponent>
 

--- a/packages/apps/purchase-page/components/OfferPage/Stages/LoginOrRegisterStage.js
+++ b/packages/apps/purchase-page/components/OfferPage/Stages/LoginOrRegisterStage.js
@@ -61,7 +61,7 @@ class LoginOrRegisterStage extends React.Component {
     loading: false,
     email: null,
     userExists: true,
-    passwordLoaded: false,
+    initialFocusSet: false,
     resetPasswordModalOpen: false,
   };
 
@@ -71,9 +71,13 @@ class LoginOrRegisterStage extends React.Component {
 
   render() {
     // focus the password input when it first loads, form focus will override if there is an error in the form
-    if (this.passwordInputEl && !this.state.passwordLoaded) {
+    if (this.passwordInputEl && !this.state.initialFocusSet && this.state.userExists) {
       this.passwordInputEl.focus();
-      this.setState({ passwordLoaded: true, });
+      this.setState({ initialFocusSet: true, });
+    }
+    else if (this.signUpButton && !this.state.initialFocusSet) {
+      this.signUpButton.focus();
+      this.setState({ initialFocusSet: true, });
     }
     const {
       router,
@@ -337,18 +341,24 @@ class LoginOrRegisterStage extends React.Component {
                                                             }
                                                             {' '}
                                                             <FelaComponent
-                                                              style={theme => ({
-                                                                color: theme.color(
+                                                              style={theme => {
+                                                                const color = theme.color(
                                                                   'loginOrRegister',
                                                                   'inFormText'
-                                                                ),
-                                                                ':visited': {
-                                                                  color: theme.color(
-                                                                    'loginOrRegister',
-                                                                    'inFormText'
-                                                                  ),
-                                                                },
-                                                              })}
+                                                                );
+                                                                return {
+                                                                  color,
+                                                                  ':visited': { color, },
+                                                                  ':focus': {
+                                                                    color,
+                                                                    textDecoration: 'underline',
+                                                                  },
+                                                                  ':hover': {
+                                                                    color,
+                                                                    textDecoration: 'underline',
+                                                                  },
+                                                                };
+                                                              }}
                                                               render={({ className, }) => (
                                                                 <a
                                                                   className={className}

--- a/packages/apps/purchase-page/theme/consts/colors.js
+++ b/packages/apps/purchase-page/theme/consts/colors.js
@@ -8,7 +8,9 @@ const htz = Object.freeze({
     bgHighlighted: [ 'primary', '-6', ],
     buttonText: [ 'primary', 'base', ],
     pricingHeadText: [ 'primary', 'base', ],
+    pricingHeadTextHighlighted: [ 'primary', 'base', ],
     paymentSummaryBorder: [ 'primary', '-3', ],
+    tableFooterTextHighlighted: [ 'positive', 'base', ],
   },
   misc: {
     link: {
@@ -39,7 +41,9 @@ const tm = Object.freeze({
     bgHighlighted: [ 'primary', '-5', ],
     buttonText: [ 'secondary', '+1', ],
     pricingHeadText: [ 'secondary', 'base', ],
+    pricingHeadTextHighlighted: [ 'secondary', '+1', ],
     paymentSummaryBorder: [ 'primary', '-2', ],
+    tableFooterTextHighlighted: [ 'positive', '+1', ],
   },
   variants: {
     button: {

--- a/packages/apps/purchase-page/theme/consts/colors.js
+++ b/packages/apps/purchase-page/theme/consts/colors.js
@@ -454,7 +454,7 @@ const colors = host => {
       primaryText: [ 'bodyText', 'base', ],
       primaryTextLabel: [ 'primary', '+1', ],
       primaryTextLabelDisabled: [ 'neutral', '-4', ],
-      primaryTextNote: [ 'neutral', '-3', ],
+      primaryTextNote: [ 'neutral', '-2', ],
       primaryAbbr: [ 'tertiary', 'base', ],
 
       // Primary Focus

--- a/packages/apps/purchase-page/theme/consts/colors.js
+++ b/packages/apps/purchase-page/theme/consts/colors.js
@@ -57,6 +57,7 @@ const tm = Object.freeze({
       opaque: {
         primaryOpaqueBg: [ 'secondary', 'base', ],
         primaryOpaqueHoverBg: [ 'secondary', '+1', ],
+        primaryOpaqueFocusBg: [ 'secondary', '+1', ],
       },
     },
     input: {
@@ -565,6 +566,7 @@ const colors = host => {
       base: '#FFA500',
       '+1': '#FA9E00',
       '+2': '#F59300',
+      // '+3': '#ED8600',
       a11yOnLight: '#A7610C',
     },
 

--- a/packages/apps/purchase-page/theme/consts/colors.js
+++ b/packages/apps/purchase-page/theme/consts/colors.js
@@ -383,7 +383,7 @@ const colors = host => {
       salesOpaqueActiveBg: [ 'sales', '+1', ],
       salesOpaqueActiveBorder: 'transparent',
       salesOpaqueActiveText: [ 'button', 'salesOpaqueText', ],
-      salesOpaqueFocusBg: [ 'sales', '+2', ],
+      salesOpaqueFocusBg: [ 'sales', '+3', ],
       salesOpaqueFocusBorder: 'transparent',
       salesOpaqueFocusText: [ 'button', 'salesOpaqueText', ],
       salesOpaqueHoverBg: [ 'sales', '+2', ],
@@ -566,7 +566,7 @@ const colors = host => {
       base: '#FFA500',
       '+1': '#FA9E00',
       '+2': '#F59300',
-      // '+3': '#ED8600',
+      '+3': '#ED8600',
       a11yOnLight: '#A7610C',
     },
 

--- a/packages/apps/purchase-page/theme/consts/i18n.js
+++ b/packages/apps/purchase-page/theme/consts/i18n.js
@@ -210,6 +210,10 @@ export const stage2 = Object.freeze({
   optionButtons: Object.freeze({
     students: 'מחיר מיוחד לסטודנטים ולחיילים',
     coupon: 'יש לי קופון הנחה',
+    regular: 'חזרה למחיר הרגיל',
+    a11yTexts: Object.freeze({
+      prefix: 'החלף ל',
+    }),
   }),
   disclaimer: Object.freeze({
     title: 'תנאי רכישה',

--- a/packages/components/htz-components/src/components/CheckBox/CheckBox.js
+++ b/packages/components/htz-components/src/components/CheckBox/CheckBox.js
@@ -35,7 +35,7 @@ const checkBoxStyle = ({ checked, isDisabled, isFocused, variant, theme, }) => (
   extend: [ theme.getTransition(1, 'swiftIn'), ],
 });
 
-const StyledCheckBox = createComponent(checkBoxStyle);
+const StyledCheckBox = createComponent(checkBoxStyle, 'div', [ 'aria-hidden', ]);
 
 const checkStyle = ({ checked, variant, theme, }) => ({
   height: '100%',
@@ -257,6 +257,7 @@ export class CheckBox extends Component {
             }}
           />
           <StyledCheckBox
+            aria-hidden="true"
             checked={controllingChecked}
             isDisabled={isDisabled}
             isFocused={this.state.isFocused}


### PR DESCRIPTION
affects: @haaretz/purchase-page, @haaretz/htz-components

Changes made according to guidelines issued following an a-2-z report


**Related issue(s):** #0

## Description
<!-- Technical description of the task -->

- Makes the green over light-green text  in stage 1 a darker shade.
- Makes input Note color a darker shade.
- Adds the words 'החלף ל' in hidden text before the special offer text in stage 2, and changes button's text for regular price to 'חזרה למחיר הרגיל'.
- Makes primary (green) buttons' background turn a darker shade on focus.
- Makes sale (orange) buttons' background turn another shade darker on focus.
- In stage 3 - initial focus is set on the 'Already registered?' option unless the current user is a registered one.
- Adds an underline to the link to the 'terms of service' on hover and on focus.
- Inside CheckBox component: The styled div that follows the input is given an aria-hidden="true" attribute. 

 



<!-- Delete if none -->
**Notes:**
<!-- Extra notes on implementation, concerns, things to notice in review -->


## Checklist

  * [ ] Approved by designer

Usability:
  * [ ] Developer
  * [ ] Project manager

Tests
  <!-- remove irrelevant (but not incomplete) entries -->
  * [ ] UI snapshot testing 
  * [ ] Unit testing
  * [ ] Integration testing
  * [ ] E2E testing
