### PR TITLE
feat(live_update): live update

### DIFF
--- a/packages/apps/haaretz.co.il/layouts/HomePageLayout.js
+++ b/packages/apps/haaretz.co.il/layouts/HomePageLayout.js
@@ -34,6 +34,7 @@ function HomePageLayout({ render, }: { render: Function, }): React.Node {
         const {
           homePage: { slots, seoData, pageDateTimeString, pageType, },
         } = data;
+        console.warn('!!! slots.main: ', slots.main);
 
         client.writeData({
           data: {

--- a/packages/apps/haaretz.co.il/layouts/queries/homepage_layout.js
+++ b/packages/apps/haaretz.co.il/layouts/queries/homepage_layout.js
@@ -122,6 +122,7 @@ export default gql`
     commentsCounts
     contentId
     representedContent
+    representedContentType
     exclusive
     exclusiveMobile
     firstParagraph

--- a/packages/components/htz-components/src/components/List/views/Pazuzu/Pazuzu.js
+++ b/packages/components/htz-components/src/components/List/views/Pazuzu/Pazuzu.js
@@ -13,6 +13,7 @@ const PazuzuQuery = gql`
         inputTemplate
         rank
         commentsCounts
+        representedContentType
         contentId
         title
         titleMobile

--- a/packages/components/htz-components/src/components/List/views/Pazuzu/PazuzuView.js
+++ b/packages/components/htz-components/src/components/List/views/Pazuzu/PazuzuView.js
@@ -9,6 +9,7 @@ import type { TeaserDataType, } from '../../../../flowTypes/TeaserDataType';
 import type { ListBiActionType, } from '../../../../flowTypes/ListBiActionType';
 
 import CommentsCount from '../../../CommentsCount/CommentsCount';
+import LiveUpdateView from '../../../LiveUpdateView/LiveUpdateView';
 import Debug from '../../../Debug/Debug';
 import GridItem from '../../../Grid/GridItem';
 import Image from '../../../Image/Image';
@@ -222,10 +223,7 @@ function PazuzuTeaser({
                 ...(isStackedOnXl
                   ? {}
                   : {
-                    marginTop: [
-                      { until: 'xl', value: 'auto', },
-                      { from: 'xl', value: '0', },
-                    ],
+                    marginTop: [ { until: 'xl', value: 'auto', }, { from: 'xl', value: '0', }, ],
                   }),
                 type: [
                   { until: 's', value: -3, },
@@ -258,10 +256,8 @@ function PazuzuTeaser({
               )}
               renderFooter={() => (
                 <React.Fragment>
-                  <TeaserAuthors
-                    authors={item.authors}
-                    miscStyles={{ fontWeight: 'bold', }}
-                  />
+                  {item.representedContentType === 'liveBlogArticle' ? <LiveUpdateView /> : null}
+                  <TeaserAuthors authors={item.authors} miscStyles={{ fontWeight: 'bold', }} />
                   {' | '}
                   <TeaserTime {...item} />
                   {' '}

--- a/packages/components/htz-components/src/components/List/views/Wong/Wong.js
+++ b/packages/components/htz-components/src/components/List/views/Wong/Wong.js
@@ -15,6 +15,7 @@ export const WongQuery = gql`
           commentsCounts
           contentId
           representedContent
+          representedContentType
           title
           titleMobile
           subtitle

--- a/packages/components/htz-components/src/components/List/views/Wong/WongView.js
+++ b/packages/components/htz-components/src/components/List/views/Wong/WongView.js
@@ -10,6 +10,7 @@ import type { ListDataType, } from '../../../../flowTypes/ListDataType';
 import type { ListBiActionType, } from '../../../../flowTypes/ListBiActionType';
 
 import { isImage, isEmbed, isGallery, } from '../../../../utils/validateType.js';
+import LiveUpdateView from '../../../LiveUpdateView/LiveUpdateView';
 import AboveBlockLink from '../../../BlockLink/AboveBlockLink';
 import CommentsCount from '../../../CommentsCount/CommentsCount';
 import GridItem from '../../../Grid/GridItem';
@@ -77,10 +78,7 @@ export default function Wong({
 }: Props): React.Node {
   const item = items[0];
   const media = item.media || null;
-  const MediaComponent = getMediaComponent(
-    media && media.kind,
-    isConrad ? Image : Picture
-  );
+  const MediaComponent = getMediaComponent(media && media.kind, isConrad ? Image : Picture);
   const relatedPadding = '2rem';
   return (
     <FelaTheme
@@ -109,15 +107,10 @@ export default function Wong({
                 justifyContent: [ { from: 'xl', value: 'flex-end', }, ],
               }}
               onClick={
-                biAction
-                  ? () => biAction({ index: 0, articleId: item.representedContent, })
-                  : null
+                biAction ? () => biAction({ index: 0, articleId: item.representedContent, }) : null
               }
               miscStyles={{
-                margin: [
-                  { until: 's', value: '0 -2rem', },
-                  { fom: 's', value: '0', },
-                ],
+                margin: [ { until: 's', value: '0 -2rem', }, { fom: 's', value: '0', }, ],
               }}
             >
               <TeaserMedia
@@ -128,9 +121,7 @@ export default function Wong({
                   { from: 'xl', value: isConrad ? 1 / 2 : 4 / 7, },
                 ]}
                 miscStyles={{
-                  paddingInlineEnd: [
-                    { from: 'xl', value: isConrad ? 0 : '2rem', },
-                  ],
+                  paddingInlineEnd: [ { from: 'xl', value: isConrad ? 0 : '2rem', }, ],
                 }}
                 onClick={
                   biAction
@@ -174,10 +165,7 @@ export default function Wong({
                         { from: 'l', until: 'xl', value: 5, },
                         { from: 'xl', value: isConrad ? 5 : 4, },
                       ]}
-                      kickerTypeScale={[
-                        { until: 's', value: 0, },
-                        { from: 's', value: -1, },
-                      ]}
+                      kickerTypeScale={[ { until: 's', value: 0, }, { from: 's', value: -1, }, ]}
                       kickerMiscStyles={{
                         marginBottom: '1rem',
                         marginInlineStart: [ { until: 's', value: '-2rem', }, ],
@@ -230,10 +218,8 @@ export default function Wong({
                 }}
                 renderFooter={() => (
                   <React.Fragment>
-                    <TeaserAuthors
-                      authors={item.authors}
-                      miscStyles={{ fontWeight: 'bold', }}
-                    />
+                    {item.representedContentType === 'liveBlogArticle' ? <LiveUpdateView /> : null}
+                    <TeaserAuthors authors={item.authors} miscStyles={{ fontWeight: 'bold', }} />
                     {' | '}
                     <TeaserTime {...item} />
                     {' '}
@@ -246,9 +232,7 @@ export default function Wong({
                         style={{
                           marginTop: '1rem',
                           fontWeight: '700',
-                          extend: [
-                            theme.mq({ until: 's', }, { display: 'none', }),
-                          ],
+                          extend: [ theme.mq({ until: 's', }, { display: 'none', }), ],
                         }}
                         render="ul"
                       >
@@ -286,9 +270,7 @@ export default function Wong({
                                         theme.type(-2, { fromBp: 'xl', }),
                                       ],
                                     }}
-                                    render={({
-                                      className: linkClassName,
-                                    }) => (
+                                    render={({ className: linkClassName, }) => (
                                       <HtzLink
                                         href={article.path}
                                         className={linkClassName}
@@ -303,13 +285,13 @@ export default function Wong({
                                       >
                                         <IconBack
                                           size={[
-                                            { until: 'xl', value: 2, },
-                                            { from: 'xl', value: 1.5, },
-                                          ]}
+                                              { until: 'xl', value: 2, },
+                                              { from: 'xl', value: 1.5, },
+                                            ]}
                                           miscStyles={{
-                                            marginInlineStart: `-${relatedPadding}`,
-                                            marginInlineEnd: '0.5rem',
-                                          }}
+                                              marginInlineStart: `-${relatedPadding}`,
+                                              marginInlineEnd: '0.5rem',
+                                            }}
                                         />
                                         {article.title}
                                       </HtzLink>
@@ -337,11 +319,7 @@ export default function Wong({
 //                               UTILS                                //
 // /////////////////////////////////////////////////////////////////////
 
-function getImageProps(
-  media: ImageDataType,
-  isConrad: boolean,
-  theme: Object
-): Object {
+function getImageProps(media: ImageDataType, isConrad: boolean, theme: Object): Object {
   return isConrad
     ? {
       data: media,
@@ -371,11 +349,7 @@ function getImageProps(
           from: 's',
           until: 'xl',
           aspect: 'headline',
-          sizes: [
-            { from: 'l', size: '570px', },
-            { from: 'm', size: '720px', },
-            { size: '552px', },
-          ],
+          sizes: [ { from: 'l', size: '570px', }, { from: 'm', size: '720px', }, { size: '552px', }, ],
           widths: [ 570, 772, 1000, ],
         },
       ],

--- a/packages/components/htz-components/src/components/List/views/Zapp/Zapp.js
+++ b/packages/components/htz-components/src/components/List/views/Zapp/Zapp.js
@@ -14,6 +14,7 @@ const ZappQuery = gql`
         commentsCounts
         contentId
         representedContent
+        representedContentType
         title
         titleMobile
         subtitle

--- a/packages/components/htz-components/src/components/List/views/Zapp/ZappItem.js
+++ b/packages/components/htz-components/src/components/List/views/Zapp/ZappItem.js
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { FelaTheme, } from 'react-fela';
 
 import CommentsCount from '../../../CommentsCount/CommentsCount';
+import LiveUpdateView from '../../../LiveUpdateView/LiveUpdateView';
 import GridItem from '../../../Grid/GridItem';
 import Picture from '../../../Image/Picture';
 import Teaser from '../../../Teaser/Teaser';
@@ -45,16 +46,11 @@ export default function ZappItem({
       isStacked={[ { from: 'l', value: true, }, ]}
     >
       <TeaserMedia
-        width={[
-          { until: 's', value: 18, },
-          { from: 's', until: 'l', value: 6 / 12, },
-        ]}
+        width={[ { until: 's', value: 18, }, { from: 's', until: 'l', value: 6 / 12, }, ]}
         data={data}
         isStacked={[ { from: 'l', value: true, }, ]}
         miscStyles={{
-          ...(hideImageOnMobile
-            ? { display: [ { until: 's', value: 'none', }, ], }
-            : {}),
+          ...(hideImageOnMobile ? { display: [ { until: 's', value: 'none', }, ], } : {}),
         }}
         onClick={biAction ? () => biAction({ index, articleId: itemId, }) : null}
       >
@@ -120,23 +116,18 @@ export default function ZappItem({
               { from: 's', until: 'l', value: 1, },
               { from: 'l', value: 0, },
             ]}
-            onClick={
-              biAction ? () => biAction({ index, articleId: itemId, }) : null
-            }
+            onClick={biAction ? () => biAction({ index, articleId: itemId, }) : null}
           />
         )}
         renderFooter={() => (
           <GridItem>
             {data.authors ? (
               <span style={{ marginInlineEnd: '1rem', }}>
-                <TeaserAuthors
-                  authors={data.authors}
-                  miscStyles={{ fontWeight: 'bold', }}
-                />
-                {(data.commentsCounts && data.commentsCounts > 4)
-                || data.rank ? (
+                {data.representedContentType === 'liveBlogArticle' ? <LiveUpdateView /> : null}
+                <TeaserAuthors authors={data.authors} miscStyles={{ fontWeight: 'bold', }} />
+                {(data.commentsCounts && data.commentsCounts > 4) || data.rank ? (
                   <span> | </span>
-                  ) : null}
+                ) : null}
               </span>
             ) : null}
             <CommentsCount commentsCount={data.commentsCounts} />

--- a/packages/components/htz-components/src/components/LiveUpdateView/LiveUpdateView.js
+++ b/packages/components/htz-components/src/components/LiveUpdateView/LiveUpdateView.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import { FelaComponent, } from 'react-fela';
+
+function LiveUpdateView() {
+  return (
+    <FelaComponent
+      style={theme => ({
+        // marginTop: '3rem',
+        display: 'inline-flex',
+        alignItems: 'center',
+        // extend: [
+        //   theme.mq({ from: 'l', }, { display: 'inline-flex', }),
+        //   theme.mq({ until: 'l', }, { display: 'none', }),
+        // ],
+      })}
+      render={({ className, theme, }) => (
+        <span className={className}>
+          <FelaComponent
+            style={{
+              color: theme.color('tertiary'),
+              margin: 'auto',
+              fontWeight: 'bold',
+              extend: [ theme.type(-3), ],
+            }}
+            render={({ className, }) => (
+              <span className={className}>{theme.liveBlogI18n.liveUpdate}</span>
+            )}
+          />
+          <FelaComponent
+            style={{
+              height: '1.3rem',
+              width: '1.3rem',
+              borderRadius: '48%',
+              backgroundColor: theme.color('tertiary'),
+              marginInlineStart: '0.5rem',
+              marginInlineEnd: '1rem',
+              marginBottom: '0.2rem',
+              animationDuration: '2.5s',
+              animationIterationCount: 'infinite',
+              animationTimingFunction: 'alternate',
+              animationName: {
+                '0%': { opacity: '0.5', },
+                '50%': { opacity: '1', },
+                '100%': { opacity: '0', },
+              },
+            }}
+            render={({ className, }) => <span className={className} />}
+          />
+        </span>
+      )}
+    />
+  );
+}
+
+export default LiveUpdateView;

--- a/packages/components/htz-components/src/flowTypes/TeaserDataType.js
+++ b/packages/components/htz-components/src/flowTypes/TeaserDataType.js
@@ -30,6 +30,7 @@ export type TeaserDataType = {
   relatedArticles?: ?({ contentId: string, path: string, title: string, }[]),
   reportingFrom?: ?string,
   representedContent: string,
+  representedContentType: ?string,
   subtitle?: ?string,
   subtitleMobile?: ?string,
   title: string,

--- a/packages/libs/app-utils/src/schema/types/teaser_in_list_type.js
+++ b/packages/libs/app-utils/src/schema/types/teaser_in_list_type.js
@@ -31,6 +31,7 @@ const TeaserInListType = new GraphQLObjectType({
     publishDate: { type: GraphQLDate, },
     contentId: { type: GraphQLID, },
     representedContent: { type: GraphQLID, },
+    representedContentType: { type: GraphQLString, },
     exclusiveMobile: { type: GraphQLString, },
     title: { type: GraphQLString, },
     commentsCounts: { type: GraphQLInt, },


### PR DESCRIPTION

affects: @haaretz/haaretz.co.il, @haaretz/htz-components, @haaretz/app-utils

**Related issue(s):** #1605 

## Description
<!-- Technical description of the task -->
1) Added `representedContentType` which indicates teaser article type to `homepage_layout` (server) query and  to Wong, Pazuzu  and Zap list queries (client).
2) Show live update when teaser represent live_blog content type is `'liveBlogArticle'`. List Views:  `Wong`, `Conard`, `Pazuzu`  and `Zapp` lists

<!-- Delete if none -->
**Notes:**
<!-- Extra notes on implementation, concerns, things to notice in review -->


## Checklist

  * [x] Approved by designer
  * [x] Approved by project manager
