### PR TITLE
fix(list img sizes): adjust image size in Donbot, Calculon and Pazuzu

### DIFF
--- a/packages/components/htz-components/src/components/List/views/Calculon/CalculonView.js
+++ b/packages/components/htz-components/src/components/List/views/Calculon/CalculonView.js
@@ -444,8 +444,8 @@ function Teaser3({
                     from: 's',
                     until: 'l',
                     sizes: [
-                      { from: 's', until: 'm', size: '180px', },
                       { from: 'm', until: 'l', size: '236px', },
+                      { from: 's', until: 'm', size: '180px', },
                     ],
                     widths: [ 180, 376, 236, 512, ],
                   },

--- a/packages/components/htz-components/src/components/List/views/Donbot/DonbotView.js
+++ b/packages/components/htz-components/src/components/List/views/Donbot/DonbotView.js
@@ -226,7 +226,7 @@ function DonbotMainTeaser({
                 defaultImgOptions: {
                   sizes: 'calc(100vw - 4rem)',
                   aspect: 'square',
-                  widths: [ 360, ],
+                  widths: [ 360, 420, 580, ],
                 },
                 sources: [
                   {
@@ -343,11 +343,11 @@ function DonbotTeaser({
                 sizes: [
                   { from: 'xl', size: '178px', },
                   { from: 'l', size: '143px', },
-                  { from: 'm', size: '343px', },
+                  { from: 'm', size: '348px', },
                   { from: 's', size: '264px', },
                   { size: 'calc(50vw - 6rem)', },
                 ],
-                widths: [ 500, 350, 270, 200, 180, 150, ],
+                widths: [ 150, 180, 200, 285, 350, 380, 565, ],
               })}
               data={item.image}
             />

--- a/packages/components/htz-components/src/components/List/views/Pazuzu/PazuzuView.js
+++ b/packages/components/htz-components/src/components/List/views/Pazuzu/PazuzuView.js
@@ -204,7 +204,7 @@ function PazuzuTeaser({
                       { from: 's', size: '264px', },
                       { size: 'calc(50vw - 4.5rem)', },
                     ],
-                    widths: [ 200, 265, 315, 350, 600, ],
+                    widths: [ 200, 240, 265, 280, 315, 350, 600, ],
                   })}
                 />
               )}


### PR DESCRIPTION
affects: @haaretz/htz-components

Added bigger sizes to srcset for Donbot's main img.
very slight tweaks in Calculon and in Pazuzu

**Related issue(s):** #1611

## Description
<!-- Technical description of the task -->


<!-- Delete if none -->
**Notes:**
<!-- Extra notes on implementation, concerns, things to notice in review -->


## Checklist

  * [ ] Approved by designer

Usability:
  * [ ] Developer
  * [ ] Project manager

Tests
  <!-- remove irrelevant (but not incomplete) entries -->
  * [ ] UI snapshot testing 
  * [ ] Unit testing
  * [ ] Integration testing
  * [ ] E2E testing
