### PR TITLE
fix(facebook-embed-css): fix Facebook video embeds style issue

### DIFF
--- a/packages/components/htz-components/src/components/Embed/elements/Facebook.js
+++ b/packages/components/htz-components/src/components/Embed/elements/Facebook.js
@@ -122,32 +122,23 @@ export default class Facebook extends React.Component<Props> {
             ) : (
               <FelaComponent
                 style={{
-                  paddingBottom: `${(height * 100) / width}%`,
-                  display: 'block',
-                  height: '0',
-                  position: 'relative',
+                  width: '100%',
+                  // In mobile devices - Facebook currently applies a fixed width in pixels,
+                  // according to the parent container. Without this next rule that results
+                  // in too large a width. (a Facebook given class makes the display inline)
+                  display: 'inline-block !important',
                 }}
-              >
-                <FelaComponent
-                  style={{
-                    height: '100%',
-                    left: '0',
-                    top: '0',
-                    position: 'absolute',
-                    width: '100%',
-                  }}
-                  render={({ className, }) => (
-                    <div
-                      className={`fb-video ${className}`}
-                      data-width="auto"
-                      data-href={this.props.source}
-                      data-allowfullscreen="true"
-                      data-autoplay="false"
-                      data-show-text={showText}
-                    />
-                  )}
-                />
-              </FelaComponent>
+                render={({ className, }) => (
+                  <div
+                    className={`fb-video ${className}`}
+                    data-width="auto"
+                    data-href={this.props.source}
+                    data-allowfullscreen="true"
+                    data-autoplay="false"
+                    data-show-text={showText}
+                  />
+                )}
+              />
             );
           }
           return null;


### PR DESCRIPTION
affects: @haaretz/htz-components

**Related issue(s):** #0

## Description
<!-- Technical description of the task -->
Facebook has changed they way it handles embeded iframe.
As a result, video embeds that included the post did not render correctly,
and in in mobile devices, the iframe width was too large.

This should fix the styling for the current way Facebook handles these embeds.


<!-- Delete if none -->
**Notes:**
<!-- Extra notes on implementation, concerns, things to notice in review -->


## Checklist

  * [ ] Approved by designer

Usability:
  * [ ] Developer
  * [ ] Project manager

Tests
  <!-- remove irrelevant (but not incomplete) entries -->
  * [ ] UI snapshot testing 
  * [ ] Unit testing
  * [ ] Integration testing
  * [ ] E2E testing
