### PR TITLE
fix(magazine_mobile_design): fix layout container padding left and right

### DIFF
--- a/packages/components/htz-components/src/components/ArticleTypes/MagazineArticle/MagazineArticle.js
+++ b/packages/components/htz-components/src/components/ArticleTypes/MagazineArticle/MagazineArticle.js
@@ -232,7 +232,16 @@ function MagazineArticle({ articleId, slots, }) {
                       || element.inputTemplate === 'com.polobase.ClickTrackerBannersWrapper'
                     ) {
                       return (
-                        <LayoutContainer miscStyles={{ paddingInlineEnd: '30rem', paddingInlineStart: '30rem', }}>
+                        <LayoutContainer
+                          miscStyles={{
+                            paddingInlineEnd: [
+                              { from: 's', value: '30rem', },
+                            ],
+                            paddingInlineStart: [
+                              { from: 's', value: '30rem', },
+                            ],
+                          }}
+                        >
                           <WideArticleLayoutRow
                             key={element.contentId}
                             hideDivider
@@ -254,7 +263,16 @@ function MagazineArticle({ articleId, slots, }) {
                       );
                     }
                     return (
-                      <LayoutContainer miscStyles={{ paddingInlineEnd: '30rem', paddingInlineStart: '30rem', }}>
+                      <LayoutContainer
+                        miscStyles={{
+                          paddingInlineEnd: [
+                            { from: 's', value: '30rem', },
+                          ],
+                          paddingInlineStart: [
+                            { from: 's', value: '30rem', },
+                          ],
+                        }}
+                      >
                         <ArticleLayoutRow
                           key={element.contentId}
                           {...(element.inputTemplate === 'com.tm.ArticleCommentsElement'


### PR DESCRIPTION
affects: @haaretz/htz-components

responsive padding

**Related issue(s):** #1646 

## Description
<!-- Technical description of the task -->


<!-- Delete if none -->
**Notes:**
<!-- Extra notes on implementation, concerns, things to notice in review -->


## Checklist

  * [ ] Approved by designer

Usability:
  * [ ] Developer
  * [ ] Project manager

Tests
  <!-- remove irrelevant (but not incomplete) entries -->
  * [ ] UI snapshot testing 
  * [ ] Unit testing
  * [ ] Integration testing
  * [ ] E2E testing
