### PR TITLE
fix(gstat): inject user to gstat in masthead user tools

### DIFF
--- a/packages/components/htz-components/src/components/Footer/Footer.js
+++ b/packages/components/htz-components/src/components/Footer/Footer.js
@@ -19,12 +19,10 @@ import AccessListByIp from '../Scripts/AccessListByIp';
 import UniversitiesPush from '../Scripts/UniversitiesPush';
 
 import FirstImpression from '../Scripts/FirstImpression';
-import GStat from '../Scripts/GStat';
 import IdxNielsen from '../Scripts/IdxNielsen';
 import CrazyEgg from '../Scripts/CrazyEgg';
 import OutbrainTVR from '../Scripts/OutbrainTVR';
 import ChartBeat from '../Scripts/ChartBeat';
-import NoSSR from '../NoSSR/NoSSR';
 
 const GET_FOOTER_ITEMS = gql`
   query FooterQuery($listId: String!) {
@@ -229,9 +227,6 @@ class Footer extends React.Component {
         <ChartBeat shouldRender={shouldRenderScripts} />
         <UniversitiesPush />
         <FirstImpression />
-        <NoSSR>
-          <GStat />
-        </NoSSR>
         <FirstImpressionPlaceHolder />
         <IdxNielsen shouldRender={shouldRenderScripts} />
         <CrazyEgg shouldRender={shouldRenderScripts} />

--- a/packages/components/htz-components/src/components/Masthead/MastheadUserTools.js
+++ b/packages/components/htz-components/src/components/Masthead/MastheadUserTools.js
@@ -5,6 +5,7 @@ import MastheadReadingList from './MastheadReadingList';
 import MastheadUserMenu from './MastheadUserMenu/MastheadUserMenu';
 import UserDispenser from '../User/UserDispenser';
 import EventTracker from '../../utils/EventTracker';
+import GStat from '../Scripts/GStat';
 
 export default function MastheadUserTools() {
   return (
@@ -19,7 +20,13 @@ export default function MastheadUserTools() {
           <EventTracker>
             {({ biAction, gaMapper, }) => (
               <UserDispenser
-                render={({ user, }) => <MastheadUserMenu userName={user.firstName} biAction={biAction} />}
+                render={({ user, }) => (
+                  <React.Fragment>
+                    <MastheadUserMenu userName={user.firstName} biAction={biAction} />
+                    {/* TODO: change gstat script location when user cache problem is fixed */}
+                    <GStat user={user} />
+                  </React.Fragment>
+                )}
               />
             )}
           </EventTracker>

--- a/packages/components/htz-components/src/components/Scripts/GStat.js
+++ b/packages/components/htz-components/src/components/Scripts/GStat.js
@@ -1,20 +1,10 @@
 /* global window localStorage fetch */
-import React, { Component, } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import config from 'config';
-import gql from 'graphql-tag';
-import ApolloConsumer from '../ApolloBoundary/ApolloConsumer';
-
-const GET_USER = gql`
-  query GetUser {
-    user @client {
-      id
-      anonymousId
-    }
-  }
-`;
 
 function GstatFunc(user) {
+  if (!user) return null;
   const paywallStatDomain = config.get('msServiceDomain');
   try {
     window.addEventListener('load', e => {
@@ -41,7 +31,6 @@ function GstatFunc(user) {
             ? new Date(GstatCampaign.lastModifiedDateTime)
             : null;
         }
-
 
         if (!lastModifiedDateTime || lastModifiedDateTime < date) {
           const domain = /^[\w-]+(\.[\w.]+)/.exec(window.location.hostname);
@@ -72,7 +61,7 @@ function GstatFunc(user) {
     console.log(e);
   }
 }
-class GStat extends Component {
+class GStat extends React.Component {
   static propTypes = {
     user: PropTypes.shape({}).isRequired,
   };
@@ -82,17 +71,13 @@ class GStat extends Component {
     GstatFunc(user);
   }
 
+  shouldComponentUpdate() {
+    return false;
+  }
+
   render() {
     return null;
   }
 }
 
-const WrappedGStat = () => (
-  <ApolloConsumer>
-    {client => {
-      const ApolloUser = client.readQuery({ query: GET_USER, });
-      return <GStat user={ApolloUser.user} />;
-    }}
-  </ApolloConsumer>
-);
-export default WrappedGStat;
+export default GStat;


### PR DESCRIPTION
affects: @haaretz/htz-components

**Related issue(s):** #0

## Description
<!-- Technical description of the task -->


<!-- Delete if none -->
**Notes:**
<!-- Extra notes on implementation, concerns, things to notice in review -->


## Checklist

  * [ ] Approved by designer

Usability:
  * [ ] Developer
  * [ ] Project manager

Tests
  <!-- remove irrelevant (but not incomplete) entries -->
  * [ ] UI snapshot testing 
  * [ ] Unit testing
  * [ ] Integration testing
  * [ ] E2E testing
