### PR TITLE
fix(init_pixel): chromepush, google and facebook pixel scripts in createDocument

### DIFF
--- a/packages/apps/haaretz.co.il/pages/_app.js
+++ b/packages/apps/haaretz.co.il/pages/_app.js
@@ -1,4 +1,4 @@
-import { createApp, InitPixel, } from '@haaretz/htz-components';
+import { createApp, } from '@haaretz/htz-components';
 import { withData, } from '@haaretz/app-utils';
 
 const initialState = () => ({
@@ -30,4 +30,4 @@ const initialState = () => ({
   pageDateTimeString: null,
 });
 
-export default withData(createApp(InitPixel), initialState);
+export default withData(createApp(), initialState);

--- a/packages/components/htz-components/src/components/Scripts/InitPixel.js
+++ b/packages/components/htz-components/src/components/Scripts/InitPixel.js
@@ -1,22 +1,14 @@
 import React, { Component, } from 'react';
-// import PropTypes from 'prop-types';
-import Head from 'next/head';
-import gql from 'graphql-tag';
-import Query from '../ApolloBoundary/Query';
-
-const GET_HOST_NAME = gql`
-  query getHostName {
-    hostname @client
-  }
-`;
-const propTypes = {};
-
-const defaultProps = {};
+import PropTypes from 'prop-types';
 
 // init pixel should be rendered only once per application
 // should not be a child of a component that gets unmounted
 // usually should be in next.js App component
 class InitPixel extends Component {
+  static propTypes = {
+    hostname: PropTypes.string.isRequired,
+  };
+
   shouldComponentUpdate() {
     return false;
   }
@@ -159,20 +151,13 @@ class InitPixel extends Component {
 
   render() {
     return (
-      <Query query={GET_HOST_NAME}>
-        {({ data: { hostname, }, }) => (
-          <Head>
-            {this.facebookPixel(hostname)}
-            {this.googlePixel(hostname)}
-            {this.chromePush(hostname)}
-          </Head>
-        )}
-      </Query>
+      <React.Fragment>
+        {this.facebookPixel(this.props.hostname)}
+        {this.googlePixel(this.props.hostname)}
+        {this.chromePush(this.props.hostname)}
+      </React.Fragment>
     );
   }
 }
-
-InitPixel.propTypes = propTypes;
-InitPixel.defaultProps = defaultProps;
 
 export default InitPixel;

--- a/packages/components/htz-components/src/createDocument.js
+++ b/packages/components/htz-components/src/createDocument.js
@@ -6,6 +6,7 @@ import config from 'config';
 import serialize from 'serialize-javascript';
 import { breakUrl, } from '@haaretz/app-utils';
 import SEO from './components/SEO/SEO';
+import InitPixel from './components/Scripts/InitPixel';
 import criticalFontLoader from './utils/criticalFontLoader';
 // import ChartBeat from './components/Scripts/ChartBeat';
 
@@ -155,6 +156,7 @@ const createDocument = ({
              * ************************* */}
             {criticalFont.style}
             {this.renderStyles()}
+            <InitPixel hostname={this.props.host} />
             {/* TODO: This should be in the theme's static rules */}
             <style
               dangerouslySetInnerHTML={{

--- a/yarn.lock
+++ b/yarn.lock
@@ -12190,7 +12190,7 @@ react-addons-shallow-compare@^15.6.2:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
 
-react-apollo@^2.2.4, react-apollo@^2.4.1:
+react-apollo@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/react-apollo/-/react-apollo-2.4.1.tgz#89db63ebacf01c1603553bb476f089492aaeab2c"
   integrity sha512-fSaiwXzY5xRmqKuGCtkMON8paL4/rKf4pB2aSI/0Ot8tn+gJisFqZ0iz9Pxvl6MHnJm1/gjJD3X1J4KmbYN2Yw==


### PR DESCRIPTION

affects: @haaretz/haaretz.co.il, @haaretz/htz-components

move initpixel scripts and logic from create app to create document file to have the script only
once in view source

**Related issue(s):** #0

## Description
<!-- Technical description of the task -->


<!-- Delete if none -->
**Notes:**
<!-- Extra notes on implementation, concerns, things to notice in review -->


## Checklist

  * [ ] Approved by designer

Usability:
  * [ ] Developer
  * [ ] Project manager

Tests
  <!-- remove irrelevant (but not incomplete) entries -->
  * [ ] UI snapshot testing 
  * [ ] Unit testing
  * [ ] Integration testing
  * [ ] E2E testing
