### PR TITLE
fix(rss-feed): divert to debug if rss list has less than 4 items

### DIFF
--- a/packages/components/htz-components/src/components/RssFeed/RssFeed.js
+++ b/packages/components/htz-components/src/components/RssFeed/RssFeed.js
@@ -1,6 +1,7 @@
 // @flow
 import * as React from 'react';
 import SalView from '../List/views/Sal/SalView';
+import Debug from '../Debug/Debug';
 
 import type { RssFeedType, } from '../../flowTypes/RssFeedType';
 import type { ListDataType, } from '../../flowTypes/ListDataType';
@@ -82,8 +83,7 @@ function rssItemImageToImage(rssImage) {
 
 export default function RssFeed(props: RssFeedType) {
   const dataAsList: ListDataType = rssDataToListData(props);
-
-  return (
+  return dataAsList.items.length >= 4 ? (
     <SalView
       {...{
         list: dataAsList,
@@ -92,5 +92,10 @@ export default function RssFeed(props: RssFeedType) {
         gaAction: null,
       }}
     />
+  ) : (
+    <Debug>
+      <p>{`element of type ${props.inputTemplate} not rendered`}</p>
+      <p>{`Expected at least 4 items but got ${dataAsList.items.length}`}</p>
+    </Debug>
   );
 }


### PR DESCRIPTION
affects: @haaretz/htz-components

**Related issue(s):** #1734

## Description
<!-- Technical description of the task -->
RssFeed list causes crash if data has less than 4 items (SalView assumes 4 items are always present).


<!-- Delete if none -->
**Notes:**
<!-- Extra notes on implementation, concerns, things to notice in review -->


## Checklist

  * [ ] Approved by designer

Usability:
  * [ ] Developer
  * [ ] Project manager

Tests
  <!-- remove irrelevant (but not incomplete) entries -->
  * [ ] UI snapshot testing 
  * [ ] Unit testing
  * [ ] Integration testing
  * [ ] E2E testing
